### PR TITLE
Corrected Congenica project for Pan4122

### DIFF
--- a/automate_demultiplex_config.py
+++ b/automate_demultiplex_config.py
@@ -486,7 +486,7 @@ panel_settings = {
 	    "mokapipe": True,
 	    "multiqc_coverage_level": 30,
 	    "RPKM_bedfile_pan_number": "Pan3624",
-	    "congenica_project": "4863",
+	    "congenica_project": "5291",
 	    "RPKM_also_analyse": vcp1_panel_list,
 	    "hsmetrics_bedfile": "Pan4287data.bed",
 	    "sambamba_bedfile": "Pan4287dataSambamba.bed",


### PR DESCRIPTION
FGFR3_R25 is congenica project 5291. The automated scripts point these samples to 4863 which doesn't exist.  The google sheet with all the tests show the project as 4863 (maybe we were given the wrong number)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/330)
<!-- Reviewable:end -->
