### PR TITLE
Feature/duty csv

### DIFF
--- a/automate_demultiplex_config.py
+++ b/automate_demultiplex_config.py
@@ -8,7 +8,7 @@ The variables defined in this module are required by the "demultiplex.py",
 import os
 
 # Set debug mode
-testing = True
+testing = False
 
 # =====location of input/output files=====
 # root of folder that contains the apps, automate_demultiplexing_logfiles and

--- a/automate_demultiplex_config.py
+++ b/automate_demultiplex_config.py
@@ -8,7 +8,7 @@ The variables defined in this module are required by the "demultiplex.py",
 import os
 
 # Set debug mode
-testing = False
+testing = True
 
 # =====location of input/output files=====
 # root of folder that contains the apps, automate_demultiplexing_logfiles and
@@ -176,34 +176,20 @@ tso500_docker_image = (
     "project-ByfFPz00jy1fk6PjpZ95F27J:file-Fz9Zyx00b5j8xKVkKv4fZ6JB"
 )
 
-# TSO500_output_parser app
-tso500_output_parser_app = (
-    "applet-GP0YXB00jy1kYKYp33yJZJ5B"  # Apps/tso500_output_parser_v1.2.1
-)
-# inputs for tso500_output_parser_app
-coverage_app_id = (
-    "project-ByfFPz00jy1fk6PjpZ95F27J:applet-G6vyyf00jy1kPkX9PJ1YkxB1"
-)
-fastqc_app_id = (
-    "project-ByfFPz00jy1fk6PjpZ95F27J:applet-FBPFfkj0jy1Q114YGQ0yQX8Y"
+sambamba_app_id = (
+    "applet-G6vyyf00jy1kPkX9PJ1YkxB1"
 )
 sompy_app_id = (
-    "project-ByfFPz00jy1fk6PjpZ95F27J:applet-G9yPb780jy1p660k6yBvQg07"
+    "applet-G9yPb780jy1p660k6yBvQg07"
 )
-multiqc_app_id = (
-    "project-ByfFPz00jy1fk6PjpZ95F27J:applet-GPgbyk00jy1kpgvggbp12Vfg"
-)
-upload_multiqc_app_id = (
-    "project-ByfFPz00jy1fk6PjpZ95F27J:applet-G2XY8QQ0p7kzvPZBJGFygP6f"
-)
-TSO500_output_parser_coverage_commands = "'-imerge_overlapping_mate_reads=true -iexclude_failed_quality_control=true -iexclude_duplicate_reads=true -imin_base_qual=%s -imin_mapping_qual=%s'"
+TSO500_coverage_commands = "-imerge_overlapping_mate_reads=true -iexclude_failed_quality_control=true -iexclude_duplicate_reads=true -imin_base_qual=%s -imin_mapping_qual=%s"
 
 # path to app which uploads multiqc report
 upload_multiqc_path = "Apps/upload_multiqc_v1.4.0"
 # RPKM path
 RPKM_path = "Apps/RPKM_using_conifer_v1.6"
 # FastQC app
-fastqc_app = "Apps/fastqc_v1.3"
+fastqc_app = "Apps/fastqc_v1.4.0"
 # bedfile folder
 bedfile_folder = "Data/BED/"
 # DNA Nexus organisation to create the project within
@@ -391,21 +377,7 @@ TSO500_docker_image_stage = " -iTSO500_ruo="
 TSO500_samplesheet_stage = " -isamplesheet="
 TSO500_analysis_options_stage = " -ianalysis_options="
 TSO500_project_name_stage = " -iproject_name="
-# TSO500 output parser stage ids
-TSO500_output_parser_project_name_stage = " -iproject_name="
-TSO500_output_parser_project_id_stage = " -iproject_id="
-TSO500_output_parser_job_id_stage = " -itso500_jobid="
-TSO500_output_parser_coverage_bedfile_id_stage = " -icoverage_bedfile_id="
-TSO500_output_parser_coverage_app_id_stage = " -icoverage_app_id="
-TSO500_output_parser_fastqc_app_id_stage = " -ifastqc_app_id="
-TSO500_output_parser_sompy_app_id_stage = " -isompy_app_id="
-TSO500_output_parser_multiqc_app_id_stage = " -imultiqc_app_id="
-TSO500_output_parser_upload_multiqc_app_id_stage = " -iupload_multiqc_app_id="
-TSO500_output_parser_coverage_commands_stage = " -icoverage_commands="
-TSO500_output_parser_coverage_level_stage = " -icoverage_level="
-TSO500_output_parser_multiqc_coverage_level_stage = (
-    " -imultiqc_coverage_level="
-)
+
 # app instance types
 TSO500_analysis_instance_high_throughput = "mem1_ssd1_v2_x72"
 TSO500_analysis_instance_low_throughput = "mem1_ssd1_v2_x36"
@@ -1665,12 +1637,12 @@ duty_csv_id = (
     "project-ByfFPz00jy1fk6PjpZ95F27J:applet-GQG5kvQ0jy1YxB6Bq4KggVq5"
 )
 duty_csv_inputs = {
-    "tso_pannumbers": "-itso_pannumbers=Pan4969,Pan5085,Pan5114 ",
+    "tso_pannumbers": "-itso_pannumbers=Pan4969,Pan5085,Pan5114",
     "stg_pannumbers": (
         "-istg_pannumbers=Pan4042,Pan4043,Pan4044,Pan4049,Pan4821,Pan4822,"
         "Pan4823,Pan4824,Pan4825,Pan4816,Pan4817,Pan4818,Pan4819,Pan4820,"
         "Pan4826,Pan4827,Pan4828,Pan4829,Pan4830,Pan4831,Pan4832,Pan4833,"
-        "Pan4834,Pan4835,Pan4836,Pan5008,Pan5010,Pan5012,Pan5014 "
+        "Pan4834,Pan4835,Pan4836,Pan5008,Pan5010,Pan5012,Pan5014"
     ),
-    "cp_capture_pannos": "-icp_capture_pannos=Pan3614,Pan4399,Pan4362 ",
+    "cp_capture_pannos": "-icp_capture_pannos=Pan3614,Pan4399,Pan4362",
 }

--- a/automate_demultiplex_config.py
+++ b/automate_demultiplex_config.py
@@ -14,19 +14,21 @@ testing = False
 # root of folder that contains the apps, automate_demultiplexing_logfiles and
 # development_area scripts
 # (2 levels up from this file)
-document_root = "/".join(os.path.dirname(os.path.realpath(__file__)).split("/")[:-2])
+document_root = "/".join(
+    os.path.dirname(os.path.realpath(__file__)).split("/")[:-2]
+)
 
 # define the runfolder pattern - only check folders startiing with 6 digits.
 runfolder_pattern = "^[0-9]{6}.*$"
 # path to run folders - use testing flag to determine folders.
 if not testing:
-	runfolders = "/media/data3/share"
+    runfolders = "/media/data3/share"
 else:
-	# when testing use a different directory
-	runfolders = "/media/data3/share/testing/"
+    # when testing use a different directory
+    runfolders = "/media/data3/share/testing/"
 
 # samplesheet folder
-samplesheets_dir = os.path.join(runfolders,"samplesheets")
+samplesheets_dir = os.path.join(runfolders, "samplesheets")
 
 # path to fastq files
 fastq_folder = "/Data/Intensities/BaseCalls"
@@ -43,12 +45,15 @@ file_demultiplexing_old = "demultiplexlog.txt"
 ignore_directories = ["samplesheets", "GlacierTest"]
 
 # TSO500 runfolder is used for testing both demultiplexing and usw script
-demultiplex_test_folder = ["999999_A01229_0496_DEMUXINTEG", "999999_M02353_0496_000000000-DEMUX",
-			   "999999_A01229_0049_AHMKTSO500"]
+demultiplex_test_folder = [
+    "999999_A01229_0496_DEMUXINTEG",
+    "999999_M02353_0496_000000000-DEMUX",
+    "999999_A01229_0049_AHMKTSO500",
+]
 
 # path to log file which records the output of the upload agent
 upload_and_setoff_workflow_logfile = (
-	"{document_root}/automate_demultiplexing_logfiles/upload_agent_script_logfiles/"
+    "{document_root}/automate_demultiplexing_logfiles/upload_agent_script_logfiles/"
 ).format(document_root=document_root)
 
 # name of log file which records the output of the upload agent
@@ -59,37 +64,37 @@ runfolder_upload_cmds = "add_runfolder_to_nexus_cmds.txt"
 
 # Path to DNA Nexus run command log file
 DNA_Nexus_workflow_logfolder = (
-	"{document_root}/automate_demultiplexing_logfiles/dx_run_commands/"
+    "{document_root}/automate_demultiplexing_logfiles/dx_run_commands/"
 ).format(document_root=document_root)
 
 # log folder containing project creation logs
 DNA_Nexus_project_creation_logfolder = (
-	"{document_root}/automate_demultiplexing_logfiles/nexus_project_creation_scripts"
-	"/create_nexus_project_"
+    "{document_root}/automate_demultiplexing_logfiles/nexus_project_creation_scripts"
+    "/create_nexus_project_"
 ).format(document_root=document_root)
 
 # folder containing demultiplex logs
 demultiplex_logfiles = (
-	"{document_root}/automate_demultiplexing_logfiles/Demultiplexing_log_files/"
+    "{document_root}/automate_demultiplexing_logfiles/Demultiplexing_log_files/"
 ).format(document_root=document_root)
 
 # path to upload agent
-upload_agent_path = ("{document_root}/apps/dnanexus-upload-agent-1.5.17-linux/ua").format(
-	document_root=document_root
-)
+upload_agent_path = (
+    "{document_root}/apps/dnanexus-upload-agent-1.5.17-linux/ua"
+).format(document_root=document_root)
 
 upload_agent_test_command = " --version"
 ua_error = "Error Message: 'Could not resolve: api.dnanexus.com"
 
 # path to backup_runfolder script
 backup_runfolder_script = (
-	"/usr/local/src/mokaguys/apps/workstation_housekeeping/backup_runfolder.py"
+    "/usr/local/src/mokaguys/apps/workstation_housekeeping/backup_runfolder.py"
 )
 
 # backup runfolder folder
 backup_runfolder_logfile = (
-	"{document_root}/automate_demultiplexing_logfiles"
-	"/backup_runfolder_logfiles"
+    "{document_root}/automate_demultiplexing_logfiles"
+    "/backup_runfolder_logfiles"
 ).format(document_root=document_root)
 
 backup_runfolder_success = "backup_runfolder INFO - END"
@@ -142,7 +147,7 @@ NexusProjectPrefix = "002_"
 project_success = 'Created new project called "%s"'
 
 # The project containing the app and data
-#app_project = "001_ToolsReferenceData:/"
+# app_project = "001_ToolsReferenceData:/"
 app_project = "project-ByfFPz00jy1fk6PjpZ95F27J:/"
 # path to the workflow in the app project
 
@@ -154,7 +159,7 @@ mokawes_path = "Workflows/MokaWES_v1.8"
 mokaamp_path = "Workflows/MokaAMP_v2.2"
 # path to mokacan
 mokacan_path = "Workflows/MokaCAN_v1.0"
-#path to mokasnp
+# path to mokasnp
 mokasnp_path = "Workflows/MokaSNP_v1.2.0"
 # path to paddy app
 peddy_path = "Apps/peddy_v1.5"
@@ -165,18 +170,32 @@ congenica_app_path = "Apps/congenica_upload_v1.3.2"
 congenica_SFTP_upload_app = "applet-GFfJpj80jy1x1Bz1P1Bk3vQf"
 
 # TSO500 app
-tso500_app = "applet-GPgkz0j0jy1Yf4XxkXjVgKfv" # Apps/TSO500_v1.5.1
+tso500_app = "applet-GPgkz0j0jy1Yf4XxkXjVgKfv"  # Apps/TSO500_v1.5.1
 tso500_app_name = "TSO500_v1.5.1"
-tso500_docker_image = "project-ByfFPz00jy1fk6PjpZ95F27J:file-Fz9Zyx00b5j8xKVkKv4fZ6JB"
+tso500_docker_image = (
+    "project-ByfFPz00jy1fk6PjpZ95F27J:file-Fz9Zyx00b5j8xKVkKv4fZ6JB"
+)
 
 # TSO500_output_parser app
-tso500_output_parser_app = "applet-GP0YXB00jy1kYKYp33yJZJ5B" # Apps/tso500_output_parser_v1.2.1
+tso500_output_parser_app = (
+    "applet-GP0YXB00jy1kYKYp33yJZJ5B"  # Apps/tso500_output_parser_v1.2.1
+)
 # inputs for tso500_output_parser_app
-coverage_app_id = "project-ByfFPz00jy1fk6PjpZ95F27J:applet-G6vyyf00jy1kPkX9PJ1YkxB1"
-fastqc_app_id = "project-ByfFPz00jy1fk6PjpZ95F27J:applet-FBPFfkj0jy1Q114YGQ0yQX8Y"
-sompy_app_id = "project-ByfFPz00jy1fk6PjpZ95F27J:applet-G9yPb780jy1p660k6yBvQg07"
-multiqc_app_id = "project-ByfFPz00jy1fk6PjpZ95F27J:applet-GPgbyk00jy1kpgvggbp12Vfg" 
-upload_multiqc_app_id = "project-ByfFPz00jy1fk6PjpZ95F27J:applet-G2XY8QQ0p7kzvPZBJGFygP6f"
+coverage_app_id = (
+    "project-ByfFPz00jy1fk6PjpZ95F27J:applet-G6vyyf00jy1kPkX9PJ1YkxB1"
+)
+fastqc_app_id = (
+    "project-ByfFPz00jy1fk6PjpZ95F27J:applet-FBPFfkj0jy1Q114YGQ0yQX8Y"
+)
+sompy_app_id = (
+    "project-ByfFPz00jy1fk6PjpZ95F27J:applet-G9yPb780jy1p660k6yBvQg07"
+)
+multiqc_app_id = (
+    "project-ByfFPz00jy1fk6PjpZ95F27J:applet-GPgbyk00jy1kpgvggbp12Vfg"
+)
+upload_multiqc_app_id = (
+    "project-ByfFPz00jy1fk6PjpZ95F27J:applet-G2XY8QQ0p7kzvPZBJGFygP6f"
+)
 TSO500_output_parser_coverage_commands = "'-imerge_overlapping_mate_reads=true -iexclude_failed_quality_control=true -iexclude_duplicate_reads=true -imin_base_qual=%s -imin_mapping_qual=%s'"
 
 # path to app which uploads multiqc report
@@ -190,6 +209,7 @@ bedfile_folder = "Data/BED/"
 # DNA Nexus organisation to create the project within
 prod_organisation = "org-viapath_prod"
 
+
 # project tags to denote live cases
 live_tag = "live"
 
@@ -201,35 +221,64 @@ mokapipe_gatk_human_exome_stage = "stage-F28y4qQ0jy1fkqfy5v2b8byx"
 mokapipe_fastqc = " -istage-Bz3YpP80jy1Y1pZKbZ35Bp0x.reads="  # FastQC Read 1
 mokapipe_bwa_reads = " -istage-Byz9BJ80jy1k2VB9xVXBp0Fg.reads_fastqgz="
 mokapipe_bwa_reads2 = " -istage-Byz9BJ80jy1k2VB9xVXBp0Fg.reads2_fastqgz="
-mokapipe_bwa_rg_sample = " -istage-Byz9BJ80jy1k2VB9xVXBp0Fg.read_group_sample="  # bwa rg samplename
+mokapipe_bwa_rg_sample = (
+    " -istage-Byz9BJ80jy1k2VB9xVXBp0Fg.read_group_sample="  # bwa rg samplename
+)
 mokapipe_bwa_ref_genome = " -istage-Byz9BJ80jy1k2VB9xVXBp0Fg.genomeindex_targz=%s"  # bwa reference genome
 mokapipe_mokapicard_vendorbed_input = " -istage-F9GK4QQ0jy1qj14PPZxxq3VG.vendor_exome_bedfile="  # HSMetrics Bed file
-mokapipe_mokapicard_capturetype_stage = " -istage-F9GK4QQ0jy1qj14PPZxxq3VG.Capture_panel=%s"
-mokapipe_haplotype_padding_input = " -i" +mokapipe_gatk_human_exome_stage + ".padding="
-mokapipe_haplotype_vcf_output_format = " -i" +mokapipe_gatk_human_exome_stage + ".output_format=both"
-mokapipe_filter_vcf_with_bedfile_bed_input = " -i" +mokapipe_filter_vcf_with_bedfile_stage + ".bedfile="
+mokapipe_mokapicard_capturetype_stage = (
+    " -istage-F9GK4QQ0jy1qj14PPZxxq3VG.Capture_panel=%s"
+)
+mokapipe_haplotype_padding_input = (
+    " -i" + mokapipe_gatk_human_exome_stage + ".padding="
+)
+mokapipe_haplotype_vcf_output_format = (
+    " -i" + mokapipe_gatk_human_exome_stage + ".output_format=both"
+)
+mokapipe_filter_vcf_with_bedfile_bed_input = (
+    " -i" + mokapipe_filter_vcf_with_bedfile_stage + ".bedfile="
+)
 mokapipe_vcf_output_name = "filtered_vcf"
 mokapipe_bam_output_name = "bam"
 mokapipe_happy_skip = " -istage-G8V205j0fB6QGKXQ2gZ5pB1z.skip=%s"
-mokapipe_happy_prefix = " -istage-G8V205j0fB6QGKXQ2gZ5pB1z.prefix=%s" 
-mokapipe_sambamba_bed_input = " -istage-F35zBKQ0jy1XpfzYPZY4bgX6.sambamba_bed=" 
-mokapipe_sambamba_min_base_qual = " -istage-F35zBKQ0jy1XpfzYPZY4bgX6.min_base_qual=10" 
-mokapipe_sambamba_min_mapping_qual = " -istage-F35zBKQ0jy1XpfzYPZY4bgX6.min_mapping_qual=20" 
-mokapipe_sambamba_coverage_level = " -istage-F35zBKQ0jy1XpfzYPZY4bgX6.coverage_level=30" 
+mokapipe_happy_prefix = " -istage-G8V205j0fB6QGKXQ2gZ5pB1z.prefix=%s"
+mokapipe_sambamba_bed_input = " -istage-F35zBKQ0jy1XpfzYPZY4bgX6.sambamba_bed="
+mokapipe_sambamba_min_base_qual = (
+    " -istage-F35zBKQ0jy1XpfzYPZY4bgX6.min_base_qual=10"
+)
+mokapipe_sambamba_min_mapping_qual = (
+    " -istage-F35zBKQ0jy1XpfzYPZY4bgX6.min_mapping_qual=20"
+)
+mokapipe_sambamba_coverage_level = (
+    " -istage-F35zBKQ0jy1XpfzYPZY4bgX6.coverage_level=30"
+)
 mokapipe_sambamba_filter_cmds = " -istage-F35zBKQ0jy1XpfzYPZY4bgX6.additional_filter_commands='not (unmapped or secondary_alignment)'"
-mokapipe_sambamba_exclude_duplicates = " -istage-F35zBKQ0jy1XpfzYPZY4bgX6.exclude_duplicate_reads=true"
-mokapipe_sambamba_exclude_failed_qual = " -istage-F35zBKQ0jy1XpfzYPZY4bgX6.exclude_failed_quality_control=true"
-mokapipe_sambamba_count_overlapping_mates = " -istage-F35zBKQ0jy1XpfzYPZY4bgX6.merge_overlapping_mate_reads=true"
+mokapipe_sambamba_exclude_duplicates = (
+    " -istage-F35zBKQ0jy1XpfzYPZY4bgX6.exclude_duplicate_reads=true"
+)
+mokapipe_sambamba_exclude_failed_qual = (
+    " -istage-F35zBKQ0jy1XpfzYPZY4bgX6.exclude_failed_quality_control=true"
+)
+mokapipe_sambamba_count_overlapping_mates = (
+    " -istage-F35zBKQ0jy1XpfzYPZY4bgX6.merge_overlapping_mate_reads=true"
+)
 mokapipe_fhPRS_skip = " -istage-G9BfkZQ0fB6jZY7v1PfJ81F6.skip=false"
 mokapipe_polyedge_stage = "stage-GK71VJ80VQgQkjvz0vyQ8YV1"
-polyedge_str = " -i%(stage_str)s.gene={} -i%(stage_str)s.chrom={} "\
-			   "-i%(stage_str)s.poly_start={} -i%(stage_str)s.poly_end={} "\
-			   "-i%(stage_str)s.skip=false" % {"stage_str": mokapipe_polyedge_stage}
+polyedge_str = (
+    " -i%(stage_str)s.gene={} -i%(stage_str)s.chrom={} "
+    "-i%(stage_str)s.poly_start={} -i%(stage_str)s.poly_end={} "
+    "-i%(stage_str)s.skip=false" % {"stage_str": mokapipe_polyedge_stage}
+)
 mokapipe_fhPRS_bedfile_input = " -istage-G9BfkZQ0fB6jZY7v1PfJ81F6.BEDfile="
-mokapipe_FH_humanexome_instance_type= "mem3_ssd1_v2_x8" # required when creating gVCFs
+mokapipe_FH_humanexome_instance_type = (
+    "mem3_ssd1_v2_x8"  # required when creating gVCFs
+)
 mokapipe_GATK_human_exome_appletID = "applet-FYZ097j0jy1ZZPx30GykP63J"
-mokapipe_FH_GATK_timeout_args = " --extra-args '{\"timeoutPolicyByExecutable\": {\"%s\": {\"*\":{\"hours\": 6}}}, \"executionPolicy\": {\"restartOn\": {\"JobTimeoutExceeded\":1,\"JMInternalError\": 1, \"UnresponsiveWorker\": 2, \"ExecutionError\":1}}}'" % (mokapipe_GATK_human_exome_appletID) # set timeout policy of 6 hours to gatk app and add the jobtimeoutexceeded reason to the auto restart list
-#Mokapipe FH_PRS BED file
+mokapipe_FH_GATK_timeout_args = (
+    ' --extra-args \'{"timeoutPolicyByExecutable": {"%s": {"*":{"hours": 6}}}, "executionPolicy": {"restartOn": {"JobTimeoutExceeded":1,"JMInternalError": 1, "UnresponsiveWorker": 2, "ExecutionError":1}}}\''
+    % (mokapipe_GATK_human_exome_appletID)
+)  # set timeout policy of 6 hours to gatk app and add the jobtimeoutexceeded reason to the auto restart list
+# Mokapipe FH_PRS BED file
 FH_PRS_bedfile_name = "Pan4909.bed"
 
 # MokaWES workflow_inputs
@@ -244,9 +293,9 @@ wes_sentieon_samplename = " -i%s.sample=" % sentieon_stage_id
 # BED file used to restrict Senteion variant calling
 wes_sentieon_targets_bed = " -i%s.targets_bed=" % sentieon_stage_id
 
-#mokasnp workflow inputs
-snp_fastqc1 = " -istage-FgPp4V00YkVJVjKF4kYkBF8v.reads=" # FastQC Read 1
-snp_fastqc2 = " -istage-FgPp4V00YkVJVjKF4kYkBF90.reads=" # FastQC Read 2
+# mokasnp workflow inputs
+snp_fastqc1 = " -istage-FgPp4V00YkVJVjKF4kYkBF8v.reads="  # FastQC Read 1
+snp_fastqc2 = " -istage-FgPp4V00YkVJVjKF4kYkBF90.reads="  # FastQC Read 2
 snp_sentieon_stage_id = "stage-FgPp4XQ0YkV48jZG4Py6F55k"
 # BED file used to restrict Senteion variant calling
 snp_sentieon_targets_bed = " -i%s.targets_bed=" % snp_sentieon_stage_id
@@ -254,21 +303,37 @@ snp_sentieon_targets_bed = " -i%s.targets_bed=" % snp_sentieon_stage_id
 snp_sentieon_samplename = " -i%s.sample=" % snp_sentieon_stage_id
 
 
-# MokaAMP - stages that may change between samples/panels 
+# MokaAMP - stages that may change between samples/panels
 mokaamp_fastq_R1_stage = " -istage-FPzGj780jy1g3p1F4F8z4J7V.reads_fastqgz="
 mokaamp_fastq_R2_stage = " -istage-FPzGj780jy1g3p1F4F8z4J7V.reads2_fastqgz="
 mokaamp_bwa_rg_sample = " -istage-FPzGj780jy1g3p1F4F8z4J7V.read_group_sample="
-mokaamp_mokapicard_bed_stage = " -istage-FPzGjV80jy1x97jg607Fg22b.vendor_exome_bedfile="
-mokaamp_mokapicard_capturetype_stage = " -istage-FPzGjV80jy1x97jg607Fg22b.Capture_panel="
-mokaamp_ampliconfilter_BEDPE_stage = " -istage-FPzGjJQ0jy1fF6505zFP6zz9.PE_BED="
-mokaamp_chanjo_cov_level_stage = " -istage-FPzGjfQ0jy1y01vG60K22qG1.coverage_level="
+mokaamp_mokapicard_bed_stage = (
+    " -istage-FPzGjV80jy1x97jg607Fg22b.vendor_exome_bedfile="
+)
+mokaamp_mokapicard_capturetype_stage = (
+    " -istage-FPzGjV80jy1x97jg607Fg22b.Capture_panel="
+)
+mokaamp_ampliconfilter_BEDPE_stage = (
+    " -istage-FPzGjJQ0jy1fF6505zFP6zz9.PE_BED="
+)
+mokaamp_chanjo_cov_level_stage = (
+    " -istage-FPzGjfQ0jy1y01vG60K22qG1.coverage_level="
+)
 mokaamp_sambamba_bed_stage = " -istage-FPzGjfQ0jy1y01vG60K22qG1.sambamba_bed="
 mokaamp_vardict_bed_stage = " -istage-G0vKZk80GfYkQx86PJGGjz9Y.bedfile="
-mokaamp_vardict_samplename_stage = " -istage-G0vKZk80GfYkQx86PJGGjz9Y.sample_name=vardict_"
+mokaamp_vardict_samplename_stage = (
+    " -istage-G0vKZk80GfYkQx86PJGGjz9Y.sample_name=vardict_"
+)
 mokaamp_varscan_bed_stage = " -istage-FPzGjp80jy1V3Jvb5z6xfpfZ.bed_file="
-mokaamp_varscan_samplename_stage = " -istage-FPzGjp80jy1V3Jvb5z6xfpfZ.samplename=varscan_"
-mokaamp_varscan_strandfilter_stage = " -istage-FPzGjp80jy1V3Jvb5z6xfpfZ.strand_filter="
-mokaamp_mpileup_cov_level_stage = " -istage-FxypXb807p1zj3g8Jv45Y54P.min_coverage="
+mokaamp_varscan_samplename_stage = (
+    " -istage-FPzGjp80jy1V3Jvb5z6xfpfZ.samplename=varscan_"
+)
+mokaamp_varscan_strandfilter_stage = (
+    " -istage-FPzGjp80jy1V3Jvb5z6xfpfZ.strand_filter="
+)
+mokaamp_mpileup_cov_level_stage = (
+    " -istage-FxypXb807p1zj3g8Jv45Y54P.min_coverage="
+)
 
 # MokaAMP - stages that SHOULDN'@'T may change between samples/panels - these are used to ensure any input files are taken from 001
 mokaamp_bwa_reference_stage = " -istage-FPzGj780jy1g3p1F4F8z4J7V.genomeindex_targz=project-ByfFPz00jy1fk6PjpZ95F27J:file-B6ZY4942J35xX095VZyQBk0v"
@@ -276,16 +341,28 @@ mokaamp_mokapicard_reference_stage = " -istage-FPzGjV80jy1x97jg607Fg22b.fasta_in
 mokaamp_vardict_reference_stage = " -istage-G0vKZk80GfYkQx86PJGGjz9Y.ref_genome=project-ByfFPz00jy1fk6PjpZ95F27J:file-ByYgX700b80gf4ZY1GxvF3Jv"
 mokaamp_varscan_reference_stage = " -istage-FPzGjp80jy1V3Jvb5z6xfpfZ.ref_genome=project-ByfFPz00jy1fk6PjpZ95F27J:file-ByYgX700b80gf4ZY1GxvF3Jv"
 
-#MokaCAN - stages which may change between samples
+# MokaCAN - stages which may change between samples
 mokacan_fastqc_r1_stage = " -istage-FPzGj6Q0jy1fF6505zFP6zz5.reads="
 mokacan_fastqc_r2_stage = " -istage-FPzGj5j0jy1x97jg607Fg229.reads="
-mokacan_picard_bedfile_stage = " -istage-FPzGjV80jy1x97jg607Fg22b.vendor_exome_bedfile="
-mokacan_picard_capturetype_stage = " -istage-FPzGjV80jy1x97jg607Fg22b.Capture_panel="
-mokacan_sambamba_bedfile_stage = " -istage-FPzGjfQ0jy1y01vG60K22qG1.sambamba_bed="
+mokacan_picard_bedfile_stage = (
+    " -istage-FPzGjV80jy1x97jg607Fg22b.vendor_exome_bedfile="
+)
+mokacan_picard_capturetype_stage = (
+    " -istage-FPzGjV80jy1x97jg607Fg22b.Capture_panel="
+)
+mokacan_sambamba_bedfile_stage = (
+    " -istage-FPzGjfQ0jy1y01vG60K22qG1.sambamba_bed="
+)
 mokacan_vardict_bedfile_stage = " -istage-FPzGjgj0jy1Q2JJF2zYx5J5k.bedfile="
-mokacan_sentieon_sample_name_stage = " -istage-FgYgB2Q087fjzvxy9f4q1K8X.sample="
-mokacan_sambamba_coverage_level_stage = " -istage-FPzGjfQ0jy1y01vG60K22qG1.coverage_level="
-mokacan_vardict_sample_name_stage = " -istage-FPzGjgj0jy1Q2JJF2zYx5J5k.sample_name=vardict_"
+mokacan_sentieon_sample_name_stage = (
+    " -istage-FgYgB2Q087fjzvxy9f4q1K8X.sample="
+)
+mokacan_sambamba_coverage_level_stage = (
+    " -istage-FPzGjfQ0jy1y01vG60K22qG1.coverage_level="
+)
+mokacan_vardict_sample_name_stage = (
+    " -istage-FPzGjgj0jy1Q2JJF2zYx5J5k.sample_name=vardict_"
+)
 mokacan_varscan_bedfile_stage = " -istage-FPzGjp80jy1V3Jvb5z6xfpfZ.bed_file="
 
 # mokacan stages with inputs that shouldn't change - these are specified to ensure any input files are taken from 001
@@ -296,8 +373,8 @@ mokacan_vardict_reference_stage = " -istage-FPzGjgj0jy1Q2JJF2zYx5J5k.ref_genome=
 mokacan_varscan_reference_stage = " -istage-FPzGjp80jy1V3Jvb5z6xfpfZ.ref_genome=project-ByfFPz00jy1fk6PjpZ95F27J:file-ByYgX700b80gf4ZY1GxvF3Jv"
 
 mokaamp_email_message = (
-	"If both MokaAMP and MokaOnc (amplivar) have been run,"
-	"please record the version of MokaOnc used."
+    "If both MokaAMP and MokaOnc (amplivar) have been run,"
+    "please record the version of MokaOnc used."
 )
 
 # Peddy
@@ -313,7 +390,7 @@ upload_multiqc_input = " -imultiqc_html="
 TSO500_docker_image_stage = " -iTSO500_ruo="
 TSO500_samplesheet_stage = " -isamplesheet="
 TSO500_analysis_options_stage = " -ianalysis_options="
-TSO500_project_name_stage= " -iproject_name="
+TSO500_project_name_stage = " -iproject_name="
 # TSO500 output parser stage ids
 TSO500_output_parser_project_name_stage = " -iproject_name="
 TSO500_output_parser_project_id_stage = " -iproject_id="
@@ -326,7 +403,9 @@ TSO500_output_parser_multiqc_app_id_stage = " -imultiqc_app_id="
 TSO500_output_parser_upload_multiqc_app_id_stage = " -iupload_multiqc_app_id="
 TSO500_output_parser_coverage_commands_stage = " -icoverage_commands="
 TSO500_output_parser_coverage_level_stage = " -icoverage_level="
-TSO500_output_parser_multiqc_coverage_level_stage = " -imultiqc_coverage_level="
+TSO500_output_parser_multiqc_coverage_level_stage = (
+    " -imultiqc_coverage_level="
+)
 # app instance types
 TSO500_analysis_instance_high_throughput = "mem1_ssd1_v2_x72"
 TSO500_analysis_instance_low_throughput = "mem1_ssd1_v2_x36"
@@ -340,19 +419,27 @@ rpkm_bamfiles_to_download_input = " -ibamfile_pannumbers="
 # if sending to multiple addresses provide in a list
 mokaguys_email = "gst-tr.mokaguys@nhs.net"
 if testing:
-	# oncology email address for email alerts
-	oncology_ops_email = mokaguys_email
-	WES_sample_name_email_list = [mokaguys_email]
+    # oncology email address for email alerts
+    oncology_ops_email = mokaguys_email
+    WES_sample_name_email_list = [mokaguys_email]
 else:
-	# oncology email address for email alerts
-	oncology_ops_email = "m.neat@nhs.net"
-	WES_sample_name_email_list = ["DNAdutyscientist@viapath.co.uk", "Suzanne.lillis@viapath.co.uk", mokaguys_email, "eblab@gstt.nhs.uk", "lu.liu@viapath.co.uk"]
+    # oncology email address for email alerts
+    oncology_ops_email = "m.neat@nhs.net"
+    WES_sample_name_email_list = [
+        "DNAdutyscientist@viapath.co.uk",
+        "Suzanne.lillis@viapath.co.uk",
+        mokaguys_email,
+        "eblab@gstt.nhs.uk",
+        "lu.liu@viapath.co.uk",
+    ]
 
 
 # DNA Nexus authentication token
-nexus_api_key_file = "{document_root}/.dnanexus_auth_token".format(document_root=document_root)
+nexus_api_key_file = "{document_root}/.dnanexus_auth_token".format(
+    document_root=document_root
+)
 with open(nexus_api_key_file, "r") as nexus_api:
-	Nexus_API_Key = nexus_api.readline().rstrip()
+    Nexus_API_Key = nexus_api.readline().rstrip()
 
 # list of DNA Nexus users with view access to project
 view_users = ["org-viapath_prod", "InterpretationRequest"]
@@ -379,1056 +466,1135 @@ congenica_samplename = " -ianalysis_name="
 # do not necessarily refer to bed files but rather project configuration (e.g. DNAnexus instances, project layout etc.)
 
 panel_list = [
-	"Pan4009", # MokaSNP
-	"Pan2835", # Twist WES
-	"Pan4940", # Twist WES for EB lab
-	"Pan3174", # WES trio
-	"Pan4081", # Swift EGFR
-	"Pan4082", # Swift 57
-	"Pan4396", # ArcherDx (Synnovis)
-	"Pan5113", # ArcherDx (BSPS)
-	"Pan5115", # ArcherDx (control)
-	"Pan4969", # TSO500 - no UTRS TERT promoter
-	"Pan5085", # TSO500 High throughput Synnovis. no UTRS TERT promoter
-	"Pan5112", # TSO500 High throughput BSPS. no UTRS TERT promoter
-	"Pan5114", # TSO500 High throughput Control. no UTRS TERT promoter
-	"Pan4579", # VCP2 M1.1 (somatic)
-	"Pan4574", # VCP2 M1.2 (somatic)
-	"Pan4042", # STG VCP2 BRCA - TO BE REMOVED IN FUTURE UPDATE
-	"Pan4043", # STG VCP3 - TO BE REMOVED IN FUTURE UPDATE
-	"Pan4044", # STG VCP1 - TO BE REMOVED IN FUTURE UPDATE
-	"Pan4049", # STG VCP2 CrCa - TO BE REMOVED IN FUTURE UPDATE
-	"Pan4119", # VCP1 Viapath R134 (FH)
-	"Pan4121", # VCP1 Viapath R184 (CF)
-	"Pan4122", # VCP1 Viapath R25 (FGFR)
-	"Pan4125", # VCP1 Viapath R73 (DMD)
-	"Pan4126", # VCP1 Viapath R337 (CADASIL)
-	"Pan4974", # VCP1 Viapath (Molecular Haemostasis) R112
-	"Pan4975", # VCP1 Viapath (Molecular Haemostasis) R115
-	"Pan4976", # VCP1 Viapath (Molecular Haemostasis) R116
-	"Pan4977", # VCP1 Viapath (Molecular Haemostasis) R117
-	"Pan4978", # VCP1 Viapath (Molecular Haemostasis) R118
-	"Pan4979", # VCP1 Viapath (Molecular Haemostasis) R119
-	"Pan4980", # VCP1 Viapath (Molecular Haemostasis) R120
-	"Pan4981", # VCP1 Viapath (Molecular Haemostasis) R121
-	"Pan4982", # VCP1 Viapath (Molecular Haemostasis) R122
-	"Pan4983", # VCP1 Viapath (Molecular Haemostasis) R123
-	"Pan4984", # VCP1 Viapath (Molecular Haemostasis) R124
-	"Pan4145", # VCP3 Viapath R79 (CMD)
-	"Pan4146", # VCP3 Viapath R81 (CM)
-	"Pan4149", # VCP2 Viapath R208 (BRCA)
-	"Pan4150", # VCP2 Viapath R207 (ovarian)
-	"Pan4127", # VCP2 Viapath R209 (colorectal)
-	"Pan4129", # VCP2 Viapath R210 (lynch)
-	"Pan4964", # VCP2 Viapath R259 (nijmegen)
-	"Pan4130", # VCP2 Viapath R211 (polyposis)
-	"Pan4132", # VCP3 Viapath R56
-	"Pan4134", # VCP3 Viapath R57
-	"Pan4136", # VCP3 Viapath R58
-	"Pan4137", # VCP3 Viapath R60
-	"Pan4138", # VCP3 Viapath R62
-	"Pan4143", # VCP3 Viapath R66
-	"Pan4144", # VCP3 Viapath R78
-	"Pan4151", # VCP3 Viapath R82
-	"Pan4314", # VCP3 Viapath R229
-	"Pan4351", # VCP3 Viapath R227
-	"Pan4387", # VCP3 Viapath R90
-	"Pan4390", # VCP3 Viapath R97
-	"Pan4821", # VCP1 STG R134 FH
-	"Pan4822", # VCP1 STG R184 CF
-	"Pan4823", # VCP1 STG R25 FGFR
-	"Pan4824", # VCP1 STG R73 DMD
-	"Pan4825", # VCP1 STG R337 CADASIL
-	"Pan4816", # VCP2 STG R208 BRCA
-	"Pan4817", # VCP2 STG R207 ovarian
-	"Pan4818", # VCP2 STG R209 colorectal
-	"Pan4819", # VCP2 STG R210 lynch
-	"Pan4820", # VCP2 STG R211 polyposis
-	"Pan4826", # VCP3 STG R56
-	"Pan4827", # VCP3 STG R57
-	"Pan4828", # VCP3 STG R58
-	"Pan4829", # VCP3 STG R60
-	"Pan4830", # VCP3 STG R62
-	"Pan4831", # VCP3 STG R66
-	"Pan4832", # VCP3 STG R78
-	"Pan4833", # VCP3 STG R79 CMD
-	"Pan4834", # VCP3 STG R81 CM
-	"Pan4835", # VCP3 STG R82 limb girdle
-	"Pan4836", # VCP3 STG R229
-	"Pan5007", # LRPCR Via R207 PMS2
-	"Pan5008", # LRPCR STG R207 PMS2
-	"Pan5009", # LRPCR Via R208 CHEK2
-	"Pan5010", # LRPCR STG R208 CHEK2
-	"Pan5011", # LRPCR Via R210 PMS2
-	"Pan5012", # LRPCR STG R210 PMS2
-	"Pan5013", # LRPCR Via R211 PMS2
-	"Pan5014", # LRPCR STG R211 PMS2
-	"Pan5015", # LRPCR Via R71 SMN1
-	"Pan5016", # LRPCR Via R239	IKBKG
+    "Pan4009",  # MokaSNP
+    "Pan2835",  # Twist WES
+    "Pan4940",  # Twist WES for EB lab
+    "Pan3174",  # WES trio
+    "Pan4081",  # Swift EGFR
+    "Pan4082",  # Swift 57
+    "Pan4396",  # ArcherDx (Synnovis)
+    "Pan5113",  # ArcherDx (BSPS)
+    "Pan5115",  # ArcherDx (control)
+    "Pan4969",  # TSO500 - no UTRS TERT promoter
+    "Pan5085",  # TSO500 High throughput Synnovis. no UTRS TERT promoter
+    "Pan5112",  # TSO500 High throughput BSPS. no UTRS TERT promoter
+    "Pan5114",  # TSO500 High throughput Control. no UTRS TERT promoter
+    "Pan4579",  # VCP2 M1.1 (somatic)
+    "Pan4574",  # VCP2 M1.2 (somatic)
+    "Pan4042",  # STG VCP2 BRCA - TO BE REMOVED IN FUTURE UPDATE
+    "Pan4043",  # STG VCP3 - TO BE REMOVED IN FUTURE UPDATE
+    "Pan4044",  # STG VCP1 - TO BE REMOVED IN FUTURE UPDATE
+    "Pan4049",  # STG VCP2 CrCa - TO BE REMOVED IN FUTURE UPDATE
+    "Pan4119",  # VCP1 Viapath R134 (FH)
+    "Pan4121",  # VCP1 Viapath R184 (CF)
+    "Pan4122",  # VCP1 Viapath R25 (FGFR)
+    "Pan4125",  # VCP1 Viapath R73 (DMD)
+    "Pan4126",  # VCP1 Viapath R337 (CADASIL)
+    "Pan4974",  # VCP1 Viapath (Molecular Haemostasis) R112
+    "Pan4975",  # VCP1 Viapath (Molecular Haemostasis) R115
+    "Pan4976",  # VCP1 Viapath (Molecular Haemostasis) R116
+    "Pan4977",  # VCP1 Viapath (Molecular Haemostasis) R117
+    "Pan4978",  # VCP1 Viapath (Molecular Haemostasis) R118
+    "Pan4979",  # VCP1 Viapath (Molecular Haemostasis) R119
+    "Pan4980",  # VCP1 Viapath (Molecular Haemostasis) R120
+    "Pan4981",  # VCP1 Viapath (Molecular Haemostasis) R121
+    "Pan4982",  # VCP1 Viapath (Molecular Haemostasis) R122
+    "Pan4983",  # VCP1 Viapath (Molecular Haemostasis) R123
+    "Pan4984",  # VCP1 Viapath (Molecular Haemostasis) R124
+    "Pan4145",  # VCP3 Viapath R79 (CMD)
+    "Pan4146",  # VCP3 Viapath R81 (CM)
+    "Pan4149",  # VCP2 Viapath R208 (BRCA)
+    "Pan4150",  # VCP2 Viapath R207 (ovarian)
+    "Pan4127",  # VCP2 Viapath R209 (colorectal)
+    "Pan4129",  # VCP2 Viapath R210 (lynch)
+    "Pan4964",  # VCP2 Viapath R259 (nijmegen)
+    "Pan4130",  # VCP2 Viapath R211 (polyposis)
+    "Pan4132",  # VCP3 Viapath R56
+    "Pan4134",  # VCP3 Viapath R57
+    "Pan4136",  # VCP3 Viapath R58
+    "Pan4137",  # VCP3 Viapath R60
+    "Pan4138",  # VCP3 Viapath R62
+    "Pan4143",  # VCP3 Viapath R66
+    "Pan4144",  # VCP3 Viapath R78
+    "Pan4151",  # VCP3 Viapath R82
+    "Pan4314",  # VCP3 Viapath R229
+    "Pan4351",  # VCP3 Viapath R227
+    "Pan4387",  # VCP3 Viapath R90
+    "Pan4390",  # VCP3 Viapath R97
+    "Pan4821",  # VCP1 STG R134 FH
+    "Pan4822",  # VCP1 STG R184 CF
+    "Pan4823",  # VCP1 STG R25 FGFR
+    "Pan4824",  # VCP1 STG R73 DMD
+    "Pan4825",  # VCP1 STG R337 CADASIL
+    "Pan4816",  # VCP2 STG R208 BRCA
+    "Pan4817",  # VCP2 STG R207 ovarian
+    "Pan4818",  # VCP2 STG R209 colorectal
+    "Pan4819",  # VCP2 STG R210 lynch
+    "Pan4820",  # VCP2 STG R211 polyposis
+    "Pan4826",  # VCP3 STG R56
+    "Pan4827",  # VCP3 STG R57
+    "Pan4828",  # VCP3 STG R58
+    "Pan4829",  # VCP3 STG R60
+    "Pan4830",  # VCP3 STG R62
+    "Pan4831",  # VCP3 STG R66
+    "Pan4832",  # VCP3 STG R78
+    "Pan4833",  # VCP3 STG R79 CMD
+    "Pan4834",  # VCP3 STG R81 CM
+    "Pan4835",  # VCP3 STG R82 limb girdle
+    "Pan4836",  # VCP3 STG R229
+    "Pan5007",  # LRPCR Via R207 PMS2
+    "Pan5008",  # LRPCR STG R207 PMS2
+    "Pan5009",  # LRPCR Via R208 CHEK2
+    "Pan5010",  # LRPCR STG R208 CHEK2
+    "Pan5011",  # LRPCR Via R210 PMS2
+    "Pan5012",  # LRPCR STG R210 PMS2
+    "Pan5013",  # LRPCR Via R211 PMS2
+    "Pan5014",  # LRPCR STG R211 PMS2
+    "Pan5015",  # LRPCR Via R71 SMN1
+    "Pan5016",  # LRPCR Via R239	IKBKG
 ]
 
 
 # create lists of pan numbers for each capture panel for use with RPKM
-#IMPORTANT: Lists below are used by the trend analysis scripts, if changed the trend analysis script will need to be updated
-vcp1_panel_list = ["Pan4119","Pan4121","Pan4122","Pan4125","Pan4126","Pan4044","Pan4821","Pan4822","Pan4823","Pan4824","Pan4825","Pan4974","Pan4975","Pan4976","Pan4977","Pan4978","Pan4979","Pan4980","Pan4981","Pan4982","Pan4983","Pan4984"]
-vcp2_panel_list = ["Pan4149","Pan4150","Pan4127","Pan4129","Pan4130","Pan4042","Pan4049","Pan4816","Pan4817","Pan4818","Pan4819","Pan4820","Pan4964"]
-vcp3_panel_list = ["Pan4132","Pan4134","Pan4136","Pan4137","Pan4138","Pan4143","Pan4144","Pan4145","Pan4146","Pan4151","Pan4043","Pan4314","Pan4351","Pan4387","Pan4390","Pan4826","Pan4827","Pan4828","Pan4829","Pan4830","Pan4831","Pan4832","Pan4833","Pan4834","Pan4835","Pan4836"]
-WES_panel_lists = ["Pan2835","Pan3174","Pan4940"]
+# IMPORTANT: Lists below are used by the trend analysis scripts, if changed the trend analysis script will need to be updated
+vcp1_panel_list = [
+    "Pan4119",
+    "Pan4121",
+    "Pan4122",
+    "Pan4125",
+    "Pan4126",
+    "Pan4044",
+    "Pan4821",
+    "Pan4822",
+    "Pan4823",
+    "Pan4824",
+    "Pan4825",
+    "Pan4974",
+    "Pan4975",
+    "Pan4976",
+    "Pan4977",
+    "Pan4978",
+    "Pan4979",
+    "Pan4980",
+    "Pan4981",
+    "Pan4982",
+    "Pan4983",
+    "Pan4984",
+]
+vcp2_panel_list = [
+    "Pan4149",
+    "Pan4150",
+    "Pan4127",
+    "Pan4129",
+    "Pan4130",
+    "Pan4042",
+    "Pan4049",
+    "Pan4816",
+    "Pan4817",
+    "Pan4818",
+    "Pan4819",
+    "Pan4820",
+    "Pan4964",
+]
+vcp3_panel_list = [
+    "Pan4132",
+    "Pan4134",
+    "Pan4136",
+    "Pan4137",
+    "Pan4138",
+    "Pan4143",
+    "Pan4144",
+    "Pan4145",
+    "Pan4146",
+    "Pan4151",
+    "Pan4043",
+    "Pan4314",
+    "Pan4351",
+    "Pan4387",
+    "Pan4390",
+    "Pan4826",
+    "Pan4827",
+    "Pan4828",
+    "Pan4829",
+    "Pan4830",
+    "Pan4831",
+    "Pan4832",
+    "Pan4833",
+    "Pan4834",
+    "Pan4835",
+    "Pan4836",
+]
+WES_panel_lists = ["Pan2835", "Pan3174", "Pan4940"]
 SNP_panel_lists = ["Pan4009"]
-archer_panel_list = ["Pan4396","Pan5113","Pan5115"]
+archer_panel_list = ["Pan4396", "Pan5113", "Pan5115"]
 swift_57G_panel_list = ["Pan4082"]
 swift_egfr_panel_list = ["Pan4081"]
-mokacan_panel_list = ["Pan4579","Pan4574"]
-LRPCR_panel_list = ["Pan5007","Pan5008","Pan5009","Pan5010","Pan5011","Pan5012","Pan5013","Pan5014","Pan5015","Pan5016"]
-tso500_panel_list = ["Pan4969","Pan5085","Pan5112","Pan5114"] # note the settings from the first item in this list are used when setting off the TSO500_output_parser commands.
+mokacan_panel_list = ["Pan4579", "Pan4574"]
+LRPCR_panel_list = [
+    "Pan5007",
+    "Pan5008",
+    "Pan5009",
+    "Pan5010",
+    "Pan5011",
+    "Pan5012",
+    "Pan5013",
+    "Pan5014",
+    "Pan5015",
+    "Pan5016",
+]
+tso500_panel_list = [
+    "Pan4969",
+    "Pan5085",
+    "Pan5112",
+    "Pan5114",
+]  # note the settings from the first item in this list are used when setting off the TSO500_output_parser commands.
 
 
 default_panel_properties = {
-	"UMI": False,
-	"UMI_bcl2fastq": None,  # eg Y145,I8,Y9I8,Y145
-	"RPKM_bedfile_pan_number": None,
-	"RPKM_also_analyse": None,  # List of Pan Numbers indicating which BAM files to download
-	"mokawes": False,
-	"joint_variant_calling": False,
-	"mokaamp": False,
-	"capture_type": "Hybridisation",  # "Amplicon" or "Hybridisation"
-	"mokacan": False,
-	"mokasnp": False,
-	"mokapipe": False,
-	"mokapipe_haplotype_caller_padding": 0,
-	"FH": False,
-	"FH_PRS_bedfile": FH_PRS_bedfile_name,
-	"polyedge": False,
-	"mokaamp_varscan_strandfilter": True,
-	"iva_upload": False,
-	"congenica_upload": True,
-	"STG": False,
-	"oncology": False,
-	"destination_command":None,
-	"congenica_credentials": "Viapath", # "Viapath" OR "STG"
-	"congenica_IR_template": "priority", # 'priority' or 'non-priority'
-	"clinical_coverage_depth": None,  # only found in mokamp command
-	"multiqc_coverage_level": 30,
-	# Note: hsmetrics_bedfile only used when BED file name differs from Pan number
-	"hsmetrics_bedfile": None,
-	# Note: variant_calling_bedfile only used when BED file differs from Pan number
-	"variant_calling_bedfile": None,
-	# Note: sambamba_bedfile only used when BED file differs from Pan number
-	"sambamba_bedfile": None,
-	# Note: mokaamp_bed_PE_input only used when BED file differs from Pan number
-	"mokaamp_bed_PE_input": None,
-	# Note: mokaamp_variant_calling_bed only used when BED file differs from Pan number
-	"mokaamp_variant_calling_bed":None,
-	"congenica_project": None,
-	"peddy": False,
-	"archerdx": False,
-	"TSO500": False,
-	"TSO500_high_throughput": False,
-	"drylab_dnanexus_id": None,
-	"masked_reference":False
+    "UMI": False,
+    "UMI_bcl2fastq": None,  # eg Y145,I8,Y9I8,Y145
+    "RPKM_bedfile_pan_number": None,
+    "RPKM_also_analyse": None,  # List of Pan Numbers indicating which BAM files to download
+    "mokawes": False,
+    "joint_variant_calling": False,
+    "mokaamp": False,
+    "capture_type": "Hybridisation",  # "Amplicon" or "Hybridisation"
+    "mokacan": False,
+    "mokasnp": False,
+    "mokapipe": False,
+    "mokapipe_haplotype_caller_padding": 0,
+    "FH": False,
+    "FH_PRS_bedfile": FH_PRS_bedfile_name,
+    "polyedge": False,
+    "mokaamp_varscan_strandfilter": True,
+    "iva_upload": False,
+    "congenica_upload": True,
+    "STG": False,
+    "oncology": False,
+    "destination_command": None,
+    "congenica_credentials": "Viapath",  # "Viapath" OR "STG"
+    "congenica_IR_template": "priority",  # 'priority' or 'non-priority'
+    "clinical_coverage_depth": None,  # only found in mokamp command
+    "multiqc_coverage_level": 30,
+    # Note: hsmetrics_bedfile only used when BED file name differs from Pan number
+    "hsmetrics_bedfile": None,
+    # Note: variant_calling_bedfile only used when BED file differs from Pan number
+    "variant_calling_bedfile": None,
+    # Note: sambamba_bedfile only used when BED file differs from Pan number
+    "sambamba_bedfile": None,
+    # Note: mokaamp_bed_PE_input only used when BED file differs from Pan number
+    "mokaamp_bed_PE_input": None,
+    # Note: mokaamp_variant_calling_bed only used when BED file differs from Pan number
+    "mokaamp_variant_calling_bed": None,
+    "congenica_project": None,
+    "peddy": False,
+    "archerdx": False,
+    "TSO500": False,
+    "TSO500_high_throughput": False,
+    "drylab_dnanexus_id": None,
+    "masked_reference": False,
 }
 
 # override default panel settings
 panel_settings = {
-	"Pan2835": {  # TWIST WES at GSTT
-		"mokawes": True,
-		"multiqc_coverage_level": 20,
-		"hsmetrics_bedfile": "Twist_Exome_RefSeq_CCDS_v1.2_targets.bed",
-		"sambamba_bedfile": "Pan493dataSambamba.bed",
-		"peddy": True
-	},
-	"Pan4940": {  # TWIST WES for EB lab
-		"mokawes": True,
-		"multiqc_coverage_level": 20,
-		"hsmetrics_bedfile": "Twist_Exome_RefSeq_CCDS_v1.2_targets.bed",
-		"sambamba_bedfile": "Pan493dataSambamba.bed",
-		"peddy": True,
-		"congenica_project": "4697",
-	},
-	"Pan3174": {  # TWIST WES TRIO at GSTT
-		"mokawes": True,
-		"multiqc_coverage_level": 20,
-		"hsmetrics_bedfile": "Twist_Exome_RefSeq_CCDS_v1.2_targets.bed",
-		"sambamba_bedfile": "Pan493dataSambamba.bed",
-		"peddy": True,
-		"congenica_upload": True
-	},
-	"Pan4081": {  # EGFR SWIFT Panel
-		"mokaamp": True,
-		"oncology": True,
-		"capture_type": "Amplicon",
-		"clinical_coverage_depth": 600,  # only found in mokamp command
-		"multiqc_coverage_level": 100,
+    "Pan2835": {  # TWIST WES at GSTT
+        "mokawes": True,
+        "multiqc_coverage_level": 20,
+        "hsmetrics_bedfile": "Twist_Exome_RefSeq_CCDS_v1.2_targets.bed",
+        "sambamba_bedfile": "Pan493dataSambamba.bed",
+        "peddy": True,
+    },
+    "Pan4940": {  # TWIST WES for EB lab
+        "mokawes": True,
+        "multiqc_coverage_level": 20,
+        "hsmetrics_bedfile": "Twist_Exome_RefSeq_CCDS_v1.2_targets.bed",
+        "sambamba_bedfile": "Pan493dataSambamba.bed",
+        "peddy": True,
+        "congenica_project": "4697",
+    },
+    "Pan3174": {  # TWIST WES TRIO at GSTT
+        "mokawes": True,
+        "multiqc_coverage_level": 20,
+        "hsmetrics_bedfile": "Twist_Exome_RefSeq_CCDS_v1.2_targets.bed",
+        "sambamba_bedfile": "Pan493dataSambamba.bed",
+        "peddy": True,
+        "congenica_upload": True,
+    },
+    "Pan4081": {  # EGFR SWIFT Panel
+        "mokaamp": True,
+        "oncology": True,
+        "capture_type": "Amplicon",
+        "clinical_coverage_depth": 600,  # only found in mokamp command
+        "multiqc_coverage_level": 100,
         "hsmetrics_bedfile": "Pan4081.bed",
-		"sambamba_bedfile": "Pan4081Sambamba.bed",
-	},
-	"Pan4082": {  # 57G SWIFT panel
-		"mokaamp": True,
-		"oncology": True,
-		"capture_type": "Amplicon",
-		"clinical_coverage_depth": 600,  # only found in mokamp command
-		"multiqc_coverage_level": 100,
+        "sambamba_bedfile": "Pan4081Sambamba.bed",
+    },
+    "Pan4082": {  # 57G SWIFT panel
+        "mokaamp": True,
+        "oncology": True,
+        "capture_type": "Amplicon",
+        "clinical_coverage_depth": 600,  # only found in mokamp command
+        "multiqc_coverage_level": 100,
         "hsmetrics_bedfile": "Pan4082.bed",
-		"sambamba_bedfile": "Pan4082Sambamba.bed",
-	},
-	"Pan4044": {  # VCP1 STG
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4399",
-		"RPKM_also_analyse": vcp1_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4203",
-		"hsmetrics_bedfile": "Pan4397data.bed",
-		"variant_calling_bedfile": "Pan4398data.bed",
-		"sambamba_bedfile": "Pan4397dataSambamba.bed",
-		"STG": True,
-	},
-	"Pan4042": {  # VCP2 STG BRCA
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3614",
-		"RPKM_also_analyse": vcp2_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "1099",
-		"hsmetrics_bedfile": "Pan4949data.bed",
-		"variant_calling_bedfile": "Pan4948data.bed",
-		"sambamba_bedfile": "Pan4949dataSambamba.bed",
-	},
-	"Pan4009": {  # MokaSNP
-		"mokasnp": True,
-		"multiqc_coverage_level": 30,
-		"variant_calling_bedfile": "Pan4009.bed",
-	},
-	"Pan4049": {  # VCP2 STG CrCa
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3614",
-		"RPKM_also_analyse": vcp2_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4202",
-		"hsmetrics_bedfile": "Pan4949data.bed",
-		"variant_calling_bedfile": "Pan4948data.bed",
-		"sambamba_bedfile": "Pan4949dataSambamba.bed",
-	},
-	"Pan4043": {  # VCP3 STG
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3974",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4201",
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-	},
-	"Pan4119": {  #VCP1 R134_Familial hypercholesterolaemia-Familial hypercholesterolaemia Small panel (Viapath)
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan4399",
-	    "congenica_project": "4664",
-	    "RPKM_also_analyse": vcp1_panel_list,
-	    "hsmetrics_bedfile": "Pan4397data.bed",
-	    "sambamba_bedfile": "Pan4397dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4398data.bed",
-	    "FH": True,
-	},
-	"Pan4121": {  #VCP1 R184 CF (Viapath)
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan4399",
-	    "congenica_project": "4862",
-	    "RPKM_also_analyse": vcp1_panel_list,
-	    "hsmetrics_bedfile": "Pan4397data.bed",
-	    "sambamba_bedfile": "Pan4397dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4398data.bed",
-	},
-	"Pan4122": {  #VCP1 R25 FGFR Viapath
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan4399",
-	    "congenica_project": "5291",
-	    "RPKM_also_analyse": vcp1_panel_list,
-	    "hsmetrics_bedfile": "Pan4397data.bed",
-	    "sambamba_bedfile": "Pan4397dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4398data.bed",
-	},
-	"Pan4125": {  #VCP1 R73 DMD (Viapath)
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan4399",
-	    "congenica_project": "4861",
-	    "RPKM_also_analyse": vcp1_panel_list,
-	    "hsmetrics_bedfile": "Pan4397data.bed",
-	    "sambamba_bedfile": "Pan4397dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4398data.bed",
-	},
-	"Pan4126": {  #VCP1 R337_CADASIL Viapath
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan4399",
-	    "congenica_project": "4865",
-	    "RPKM_also_analyse": vcp1_panel_list,
-	    "hsmetrics_bedfile": "Pan4397data.bed",
-	    "sambamba_bedfile": "Pan4397dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4398data.bed",
-	},
-	"Pan4974": {  #VCP1 Viapath (Molecular Haemostasis) R112
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan4399",
-	    "congenica_project": "4699",
-	    "RPKM_also_analyse": vcp1_panel_list,
-	    "hsmetrics_bedfile": "Pan4397data.bed",
-	    "sambamba_bedfile": "Pan4397dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4398data.bed",
-	},
-	"Pan4975": {  #VCP1 Viapath (Molecular Haemostasis) R115
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan4399",
-	    "congenica_project": "4699",
-	    "RPKM_also_analyse": vcp1_panel_list,
-	    "hsmetrics_bedfile": "Pan4397data.bed",
-	    "sambamba_bedfile": "Pan4397dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4398data.bed",
-	},
-	"Pan4976": {  #VCP1 Viapath (Molecular Haemostasis) R116
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan4399",
-	    "congenica_project": "4699",
-	    "RPKM_also_analyse": vcp1_panel_list,
-	    "hsmetrics_bedfile": "Pan4397data.bed",
-	    "sambamba_bedfile": "Pan4397dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4398data.bed",
-	},
-	"Pan4977": {  #VCP1 Viapath (Molecular Haemostasis) R117
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan4399",
-	    "congenica_project": "4699",
-	    "RPKM_also_analyse": vcp1_panel_list,
-	    "hsmetrics_bedfile": "Pan4397data.bed",
-	    "sambamba_bedfile": "Pan4397dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4398data.bed",
-	},
-	"Pan4978": {  #VCP1 Viapath (Molecular Haemostasis) R118
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan4399",
-	    "congenica_project": "4699",
-	    "RPKM_also_analyse": vcp1_panel_list,
-	    "hsmetrics_bedfile": "Pan4397data.bed",
-	    "sambamba_bedfile": "Pan4397dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4398data.bed",
-	},
-	"Pan4979": {  #VCP1 Viapath (Molecular Haemostasis) R119
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan4399",
-	    "congenica_project": "4699",
-	    "RPKM_also_analyse": vcp1_panel_list,
-	    "hsmetrics_bedfile": "Pan4397data.bed",
-	    "sambamba_bedfile": "Pan4397dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4398data.bed",
-	},
-	"Pan4980": {  #VCP1 Viapath (Molecular Haemostasis) R120
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan4399",
-	    "congenica_project": "4699",
-	    "RPKM_also_analyse": vcp1_panel_list,
-	    "hsmetrics_bedfile": "Pan4397data.bed",
-	    "sambamba_bedfile": "Pan4397dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4398data.bed",
-	},
-	"Pan4981": {  #VCP1 Viapath (Molecular Haemostasis) R121
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan4399",
-	    "congenica_project": "4699",
-	    "RPKM_also_analyse": vcp1_panel_list,
-	    "hsmetrics_bedfile": "Pan4397data.bed",
-	    "sambamba_bedfile": "Pan4397dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4398data.bed",
-	},
-	"Pan4982": {  #VCP1 Viapath (Molecular Haemostasis) R122
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan4399",
-	    "congenica_project": "4699",
-	    "RPKM_also_analyse": vcp1_panel_list,
-	    "hsmetrics_bedfile": "Pan4397data.bed",
-	    "sambamba_bedfile": "Pan4397dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4398data.bed",
-	},
-	"Pan4983": {  #VCP1 Viapath (Molecular Haemostasis) R123
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan4399",
-	    "congenica_project": "4699",
-	    "RPKM_also_analyse": vcp1_panel_list,
-	    "hsmetrics_bedfile": "Pan4397data.bed",
-	    "sambamba_bedfile": "Pan4397dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4398data.bed",
-	},
-	"Pan4984": {  #VCP1 Viapath (Molecular Haemostasis) R124
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan4399",
-	    "congenica_project": "4699",
-	    "RPKM_also_analyse": vcp1_panel_list,
-	    "hsmetrics_bedfile": "Pan4397data.bed",
-	    "sambamba_bedfile": "Pan4397dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4398data.bed",
-	},
-	"Pan4149": {  #VCP2 BRCA (Viapath)
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan3614",
-	    "congenica_project": "4665",
-	    "RPKM_also_analyse": vcp2_panel_list,
-	    "hsmetrics_bedfile": "Pan4949data.bed",
-	    "sambamba_bedfile": "Pan4949dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4948data.bed",
-	},
-	"Pan4964": {  #VCP2 R259 nijmegen breakage (Viapath)
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan3614",
-	    "congenica_project": "9118",
-	    "RPKM_also_analyse": vcp2_panel_list,
-	    "hsmetrics_bedfile": "Pan4949data.bed",
-	    "sambamba_bedfile": "Pan4949dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4948data.bed",
-	},
-	"Pan4150": {  #VCP2 R207 ovarian cancer (Viapath)
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan3614",
-	    "congenica_project": "4864",
-	    "RPKM_also_analyse": vcp2_panel_list,
-	    "hsmetrics_bedfile": "Pan4949data.bed",
-	    "sambamba_bedfile": "Pan4949dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4948data.bed",
-		"polyedge": "MSH2",
-	},
-	"Pan4127": {  #VCP2 R209 colorectal cancer (Viapath)
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan3614",
-	    "congenica_project": "5093",
-	    "RPKM_also_analyse": vcp2_panel_list,
-	    "hsmetrics_bedfile": "Pan4949data.bed",
-	    "sambamba_bedfile": "Pan4949dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4948data.bed",
-	},
-	"Pan4129": {  #VCP2 R210 Lynch syndrome (Viapath)
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan3614",
-	    "congenica_project": "5094",
-	    "RPKM_also_analyse": vcp2_panel_list,
-	    "hsmetrics_bedfile": "Pan4949data.bed",
-	    "sambamba_bedfile": "Pan4949dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4948data.bed",
-		"polyedge": "MSH2",
-	},
-	"Pan4130": {  #VCP2 R211 polyposis (Viapath)
-	    "mokapipe": True,
-	    "multiqc_coverage_level": 30,
-	    "RPKM_bedfile_pan_number": "Pan3614",
-	    "congenica_project": "5095",
-	    "RPKM_also_analyse": vcp2_panel_list,
-	    "hsmetrics_bedfile": "Pan4949data.bed",
-	    "sambamba_bedfile": "Pan4949dataSambamba.bed",
-	    "variant_calling_bedfile": "Pan4948data.bed",
-		"polyedge": "MSH2",
-	},
-	"Pan4132": {  #VCP3 R56 (Viapath)
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4362",
-		"congenica_project": "5092",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-	},
-	"Pan4134": {  #VCP3 R57 (Viapath)
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4362",
-		"congenica_project": "5092",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-		"variant_calling_bedfile": "Pan4995data.bed"
-	},
-	"Pan4136": {  #VCP3 R58 (Viapath)
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4362",
-		"congenica_project": "5092",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-	},
-	"Pan4137": {  #VCP3 R60 (Viapath)
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4362",
-		"congenica_project": "5092",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-	},
-	"Pan4138": {  #VCP3 R62 (Viapath)
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4362",
-		"congenica_project": "5092",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-	},
-	"Pan4143": {  #VCP3 R66 (Viapath)
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4362",
-		"congenica_project": "5092",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-	},
-	"Pan4144": {  #VCP3 R78 (Viapath)
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4362",
-		"congenica_project": "5092",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-	},
-	"Pan4145": {  #VCP3 R79 - CMD (Viapath)
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4362",
-		"congenica_project": "4666",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-	},
-	"Pan4146": {  #VCP3 R81 CM (Viapath)
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4362",
-		"congenica_project": "4666",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-	},
-	"Pan4151": {  #VCP3 R82 limb girdle (Viapath)
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4362",
-		"congenica_project": "5092",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-	},
-	"Pan4351": { #VCP3 R227 (Viapath)
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4362",
-		"congenica_project": "5522",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-	},
-	"Pan4387": { #VCP3 R90 Bleeding and platelet disorders (Viapath)
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4362",
-		"congenica_project": "4699",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-	},
-	"Pan4390": { #VCP3 R97 Thrombophilia with a likely monogenic cause (Viapath)
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4362",
-		"congenica_project": "4699",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-	},
-	"Pan4314": { #VCP3 R229 (Viapath)
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4362",
-		"congenica_project": "5290",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-	},
-	"Pan4396": { #ArcherDx (Synnovis)
-		"archerdx": True,
-		"congenica_upload": False,
-	},
-		"Pan5113": { #ArcherDx (BSPS)
-		"archerdx": True,
-		"congenica_upload": False,
-	},
-		"Pan5115": { #ArcherDx (Control)
-		"archerdx": True,
-		"congenica_upload": False,
-	},
-	"Pan4574" :{ # somatic VCP2 M1.2
-		"mokacan": True,
-		"congenica_upload": False,
-		"variant_calling_bedfile": "Pan4577data.bed",
-		"hsmetrics_bedfile": "Pan4949data.bed",
-		"clinical_coverage_depth" : 200,
-	},
-	"Pan4579" :{ # somatic VCP2 M1.1
-		"mokacan": True,
-		"congenica_upload": False,
-		"variant_calling_bedfile": "Pan4578data.bed",
-		"hsmetrics_bedfile": "Pan4949data.bed",
-		"clinical_coverage_depth" : 200,
-	},
-	"Pan4969" : { # TSO500 no UTRs. TERT promoter
-		"TSO500": True,
-		"sambamba_bedfile": "Pan4969dataSambamba.bed", # NOTE All TSO500 output parser settings are currently taken from the first pan number listed in tso500_panel_list
-		"clinical_coverage_depth" : 100,
-		"multiqc_coverage_level": 100,
-		"coverage_min_basecall_qual":25,
-		"coverage_min_mapping_qual":30,
-	},
-	"Pan5085" : { # TSO500 High throughput Synnovis. no UTRs. TERT promoter
-		"TSO500": True,
-		"TSO500_high_throughput": True,
-		"sambamba_bedfile": "Pan4969dataSambamba.bed", # NOTE All TSO500 output parser settings are currently taken from the first pan number listed in tso500_panel_list
-		"clinical_coverage_depth" : 100,
-		"multiqc_coverage_level": 100,
-		"coverage_min_basecall_qual":25,
-		"coverage_min_mapping_qual":30,
-	},
-	"Pan5112" : { # TSO500 High throughput BSPS. no UTRs. TERT promoter
-		"TSO500": True,
-		"TSO500_high_throughput": True,
-		"sambamba_bedfile": "Pan4969dataSambamba.bed", # NOTE All TSO500 output parser settings are currently taken from the first pan number listed in tso500_panel_list
-		"clinical_coverage_depth" : 100,
-		"multiqc_coverage_level": 100,
-		"coverage_min_basecall_qual":25,
-		"coverage_min_mapping_qual":30,
-		"drylab_dnanexus_id": "BSPS_MD"
-	},
-		"Pan5114" : { # TSO500 High throughput Control. no UTRs. TERT promoter
-		"TSO500": True,
-		"TSO500_high_throughput": True,
-		"sambamba_bedfile": "Pan4969dataSambamba.bed", # NOTE All TSO500 output parser settings are currently taken from the first pan number listed in tso500_panel_list
-		"clinical_coverage_depth" : 100,
-		"multiqc_coverage_level": 100,
-		"coverage_min_basecall_qual":25,
-		"coverage_min_mapping_qual":30,
-		"drylab_dnanexus_id": "BSPS_MD"
-	},
-	"Pan4821": {  # VCP1 STG R134_FH
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4399",
-		"RPKM_also_analyse": vcp1_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4203",
-		"hsmetrics_bedfile": "Pan4397data.bed",
-		"variant_calling_bedfile": "Pan4398data.bed",
-		"sambamba_bedfile": "Pan4397dataSambamba.bed",
-		"STG": True,
-		"FH": True,
-	},
-	"Pan4822": {  # VCP1 STG R184_CF
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4399",
-		"RPKM_also_analyse": vcp1_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4203",
-		"hsmetrics_bedfile": "Pan4397data.bed",
-		"variant_calling_bedfile": "Pan4398data.bed",
-		"sambamba_bedfile": "Pan4397dataSambamba.bed",
-		"STG": True,
-	},
-	"Pan4823": {  # VCP1 STG R25_FGFR
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4399",
-		"RPKM_also_analyse": vcp1_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4203",
-		"hsmetrics_bedfile": "Pan4397data.bed",
-		"variant_calling_bedfile": "Pan4398data.bed",
-		"sambamba_bedfile": "Pan4397dataSambamba.bed",
-		"STG": True,
-	},
-	"Pan4824": {  # VCP1 STG R73_DMD
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4399",
-		"RPKM_also_analyse": vcp1_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4203",
-		"hsmetrics_bedfile": "Pan4397data.bed",
-		"variant_calling_bedfile": "Pan4398data.bed",
-		"sambamba_bedfile": "Pan4397dataSambamba.bed",
-		"STG": True,
-	},
-	"Pan4825": {  # VCP1 STG R337_cadasil
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan4399",
-		"RPKM_also_analyse": vcp1_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4203",
-		"hsmetrics_bedfile": "Pan4397data.bed",
-		"variant_calling_bedfile": "Pan4398data.bed",
-		"sambamba_bedfile": "Pan4397dataSambamba.bed",
-		"STG": True,
-	},
-	"Pan4826": {  # VCP3 STG R56
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3974",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4201",
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-	},
-	"Pan4827": {  # VCP3 STG R57
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3974",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4201",
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-	},
-	"Pan4828": {  # VCP3 STG R58
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3974",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4201",
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-	},
-	"Pan4829": {  # VCP3 STG R60
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3974",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4201",
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-	},
-	"Pan4830": {  # VCP3 STG R62
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3974",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4201",
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-	},
-	"Pan4831": {  # VCP3 STG R66
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3974",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4201",
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-	},
-	"Pan4832": {  # VCP3 STG R78
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3974",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4201",
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-	},
-	"Pan4833": {  # VCP3 STG R79
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3974",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4201",
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-	},
-	"Pan4834": {  # VCP3 STG R81
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3974",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4201",
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-	},
-	"Pan4835": {  # VCP3 STG R82
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3974",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4201",
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-	},
-	"Pan4836": {  # VCP3 STG R229
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3974",
-		"RPKM_also_analyse": vcp3_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4201",
-		"hsmetrics_bedfile": "Pan4995data.bed",
-		"variant_calling_bedfile": "Pan4995data.bed",
-		"sambamba_bedfile": "Pan4995dataSambamba.bed",
-	},
-	"Pan4818": {  # VCP2 STG R209
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3614",
-		"RPKM_also_analyse": vcp2_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4202",
-		"hsmetrics_bedfile": "Pan4949data.bed",
-		"variant_calling_bedfile": "Pan4948data.bed",
-		"sambamba_bedfile": "Pan4949dataSambamba.bed",
-	},
-	"Pan4819": {  # VCP2 STG R210
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3614",
-		"RPKM_also_analyse": vcp2_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4202",
-		"hsmetrics_bedfile": "Pan4949data.bed",
-		"variant_calling_bedfile": "Pan4948data.bed",
-		"sambamba_bedfile": "Pan4949dataSambamba.bed",
-		"polyedge": "MSH2",
-	},
-	"Pan4820": {  # VCP2 STG R211
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3614",
-		"RPKM_also_analyse": vcp2_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "4202",
-		"hsmetrics_bedfile": "Pan4949data.bed",
-		"variant_calling_bedfile": "Pan4948data.bed",
-		"sambamba_bedfile": "Pan4949dataSambamba.bed",
-		"polyedge": "MSH2",
-	},
-	"Pan4816": {  # VCP2 STG R208
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3614",
-		"RPKM_also_analyse": vcp2_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "1099",
-		"hsmetrics_bedfile": "Pan4949data.bed",
-		"variant_calling_bedfile": "Pan4948data.bed",
-		"sambamba_bedfile": "Pan4949dataSambamba.bed",
-	},
-	"Pan4817": {  # VCP2 STG R207
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"RPKM_bedfile_pan_number": "Pan3614",
-		"RPKM_also_analyse": vcp2_panel_list,
-		"congenica_credentials": "STG",
-		"congenica_IR_template":"non-priority",
-		"congenica_project": "1099",
-		"hsmetrics_bedfile": "Pan4949data.bed",
-		"variant_calling_bedfile": "Pan4948data.bed",
-		"sambamba_bedfile": "Pan4949dataSambamba.bed",
-		"polyedge": "MSH2",
-	},
-	"Pan5007": {  # LRPCR Via R207 PMS2
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"capture_type": "Amplicon",
-		"congenica_IR_template":"priority",
-		"congenica_project": "9986",
-		"hsmetrics_bedfile": "Pan4967_reference.bed", # LRPCR amplicon BED file
-		"variant_calling_bedfile": "Pan4767data.bed",
-		"sambamba_bedfile": "Pan5018dataSambamba.bed",
-		"masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q", # hs37d5_Pan4967.bwa-index.tar.gz
-	},
-	"Pan5008": {  # LRPCR STG R207 PMS2
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"capture_type": "Amplicon",
-		"congenica_IR_template":"non-priority", 
-		"congenica_project": "10010",
-		"congenica_credentials": "STG",
-		"hsmetrics_bedfile": "Pan4967_reference.bed", # LRPCR amplicon BED file
-		"variant_calling_bedfile": "Pan4767data.bed",
-		"sambamba_bedfile": "Pan5018dataSambamba.bed",
-		"masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q", # hs37d5_Pan4967.bwa-index.tar.gz
-	},
-	"Pan5011": {  # LRPCR Via R210 PMS2
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"capture_type": "Amplicon",
-		"congenica_IR_template":"priority",
-		"congenica_project": "9981", 
-		"hsmetrics_bedfile": "Pan4967_reference.bed", # LRPCR amplicon BED file
-		"variant_calling_bedfile": "Pan4767data.bed",
-		"sambamba_bedfile": "Pan5018dataSambamba.bed",
-		"masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q", # hs37d5_Pan4967.bwa-index.tar.gz
-	},
-	"Pan5012": {  # LRPCR STG R210 PMS2
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"capture_type": "Amplicon",
-		"congenica_IR_template":"non-priority", 
-		"congenica_project": "10042",
-		"congenica_credentials": "STG",
-		"hsmetrics_bedfile": "Pan4967_reference.bed", # LRPCR amplicon BED file
-		"variant_calling_bedfile": "Pan4767data.bed",
-		"sambamba_bedfile": "Pan5018dataSambamba.bed",
-		"masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q", # hs37d5_Pan4967.bwa-index.tar.gz
-	},
-	"Pan5013": {  # LRPCR Via R211 PMS2
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"capture_type": "Amplicon",
-		"congenica_IR_template":"priority", 
-		"congenica_project": "9982",
-		"hsmetrics_bedfile": "Pan4967_reference.bed", # LRPCR amplicon BED file
-		"variant_calling_bedfile": "Pan4767data.bed",
-		"sambamba_bedfile": "Pan5018dataSambamba.bed",
-		"masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q", # hs37d5_Pan4967.bwa-index.tar.gz
-	},
-	"Pan5014": {  # LRPCR STG R211 PMS2
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"capture_type": "Amplicon",
-		"congenica_IR_template":"non-priority", 
-		"congenica_project": "10042",
-		"congenica_credentials": "STG",
-		"hsmetrics_bedfile": "Pan4967_reference.bed", # LRPCR amplicon BED file
-		"variant_calling_bedfile": "Pan4767data.bed",
-		"sambamba_bedfile": "Pan5018dataSambamba.bed",
-		"masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q", # hs37d5_Pan4967.bwa-index.tar.gz
-	},
-	"Pan5009": {  # LRPCR Via R208 CHEK2
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"capture_type": "Amplicon",
-		"congenica_IR_template":"priority",
-		"congenica_project": "9984",
-		"hsmetrics_bedfile": "Pan4967_reference.bed", # LRPCR amplicon BED file
-		"variant_calling_bedfile": "Pan4767data.bed",
-		"sambamba_bedfile": "Pan5018dataSambamba.bed",
-		"masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q" # hs37d5_Pan4967.bwa-index.tar.gz
-	},
-	"Pan5010": {  # LRPCR STG R208 CHEK2
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"capture_type": "Amplicon",
-		"congenica_IR_template":"non-priority", 
-		"congenica_project": "10009", 
-		"congenica_credentials": "STG",
-		"hsmetrics_bedfile": "Pan4967_reference.bed", # LRPCR amplicon BED file
-		"variant_calling_bedfile": "Pan4766data.bed",
-		"sambamba_bedfile": "Pan5018dataSambamba.bed",
-		"masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q" # hs37d5_Pan4967.bwa-index.tar.gz
-	},
-	"Pan5015": {  # LRPCR Via R71 SMN1
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"capture_type": "Amplicon",
-		"congenica_IR_template":"non-priority", #TODO
-		"congenica_project": "9547", #TODO
-		"hsmetrics_bedfile": "Pan4967_reference.bed", # LRPCR amplicon BED file
-		"variant_calling_bedfile": "Pan4971data.bed",
-		"sambamba_bedfile": "Pan5018dataSambamba.bed",
-		"masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q" # hs37d5_Pan4967.bwa-index.tar.gz
-	},
-	"Pan5016": {  # LRPCR Via R239 IKBKG
-		"mokapipe": True,
-		"multiqc_coverage_level": 30,
-		"capture_type": "Amplicon",
-		"congenica_IR_template":"priority", 
-		"congenica_project": "9985",
-		"hsmetrics_bedfile": "Pan4967_reference.bed", # LRPCR amplicon BED file
-		"variant_calling_bedfile": "Pan4768data.bed",
-		"sambamba_bedfile": "Pan5018dataSambamba.bed",
-		"masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q" # hs37d5_Pan4967.bwa-index.tar.gz
-	},
+        "sambamba_bedfile": "Pan4082Sambamba.bed",
+    },
+    "Pan4044": {  # VCP1 STG
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4203",
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "STG": True,
+    },
+    "Pan4042": {  # VCP2 STG BRCA
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3614",
+        "RPKM_also_analyse": vcp2_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "1099",
+        "hsmetrics_bedfile": "Pan4949data.bed",
+        "variant_calling_bedfile": "Pan4948data.bed",
+        "sambamba_bedfile": "Pan4949dataSambamba.bed",
+    },
+    "Pan4009": {  # MokaSNP
+        "mokasnp": True,
+        "multiqc_coverage_level": 30,
+        "variant_calling_bedfile": "Pan4009.bed",
+    },
+    "Pan4049": {  # VCP2 STG CrCa
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3614",
+        "RPKM_also_analyse": vcp2_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4202",
+        "hsmetrics_bedfile": "Pan4949data.bed",
+        "variant_calling_bedfile": "Pan4948data.bed",
+        "sambamba_bedfile": "Pan4949dataSambamba.bed",
+    },
+    "Pan4043": {  # VCP3 STG
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3974",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4201",
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+    },
+    "Pan4119": {  # VCP1 R134_Familial hypercholesterolaemia-Familial hypercholesterolaemia Small panel (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "congenica_project": "4664",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+        "FH": True,
+    },
+    "Pan4121": {  # VCP1 R184 CF (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "congenica_project": "4862",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+    },
+    "Pan4122": {  # VCP1 R25 FGFR Viapath
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "congenica_project": "5291",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+    },
+    "Pan4125": {  # VCP1 R73 DMD (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "congenica_project": "4861",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+    },
+    "Pan4126": {  # VCP1 R337_CADASIL Viapath
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "congenica_project": "4865",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+    },
+    "Pan4974": {  # VCP1 Viapath (Molecular Haemostasis) R112
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "congenica_project": "4699",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+    },
+    "Pan4975": {  # VCP1 Viapath (Molecular Haemostasis) R115
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "congenica_project": "4699",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+    },
+    "Pan4976": {  # VCP1 Viapath (Molecular Haemostasis) R116
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "congenica_project": "4699",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+    },
+    "Pan4977": {  # VCP1 Viapath (Molecular Haemostasis) R117
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "congenica_project": "4699",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+    },
+    "Pan4978": {  # VCP1 Viapath (Molecular Haemostasis) R118
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "congenica_project": "4699",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+    },
+    "Pan4979": {  # VCP1 Viapath (Molecular Haemostasis) R119
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "congenica_project": "4699",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+    },
+    "Pan4980": {  # VCP1 Viapath (Molecular Haemostasis) R120
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "congenica_project": "4699",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+    },
+    "Pan4981": {  # VCP1 Viapath (Molecular Haemostasis) R121
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "congenica_project": "4699",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+    },
+    "Pan4982": {  # VCP1 Viapath (Molecular Haemostasis) R122
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "congenica_project": "4699",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+    },
+    "Pan4983": {  # VCP1 Viapath (Molecular Haemostasis) R123
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "congenica_project": "4699",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+    },
+    "Pan4984": {  # VCP1 Viapath (Molecular Haemostasis) R124
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "congenica_project": "4699",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+    },
+    "Pan4149": {  # VCP2 BRCA (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3614",
+        "congenica_project": "4665",
+        "RPKM_also_analyse": vcp2_panel_list,
+        "hsmetrics_bedfile": "Pan4949data.bed",
+        "sambamba_bedfile": "Pan4949dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4948data.bed",
+    },
+    "Pan4964": {  # VCP2 R259 nijmegen breakage (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3614",
+        "congenica_project": "9118",
+        "RPKM_also_analyse": vcp2_panel_list,
+        "hsmetrics_bedfile": "Pan4949data.bed",
+        "sambamba_bedfile": "Pan4949dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4948data.bed",
+    },
+    "Pan4150": {  # VCP2 R207 ovarian cancer (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3614",
+        "congenica_project": "4864",
+        "RPKM_also_analyse": vcp2_panel_list,
+        "hsmetrics_bedfile": "Pan4949data.bed",
+        "sambamba_bedfile": "Pan4949dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4948data.bed",
+        "polyedge": "MSH2",
+    },
+    "Pan4127": {  # VCP2 R209 colorectal cancer (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3614",
+        "congenica_project": "5093",
+        "RPKM_also_analyse": vcp2_panel_list,
+        "hsmetrics_bedfile": "Pan4949data.bed",
+        "sambamba_bedfile": "Pan4949dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4948data.bed",
+    },
+    "Pan4129": {  # VCP2 R210 Lynch syndrome (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3614",
+        "congenica_project": "5094",
+        "RPKM_also_analyse": vcp2_panel_list,
+        "hsmetrics_bedfile": "Pan4949data.bed",
+        "sambamba_bedfile": "Pan4949dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4948data.bed",
+        "polyedge": "MSH2",
+    },
+    "Pan4130": {  # VCP2 R211 polyposis (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3614",
+        "congenica_project": "5095",
+        "RPKM_also_analyse": vcp2_panel_list,
+        "hsmetrics_bedfile": "Pan4949data.bed",
+        "sambamba_bedfile": "Pan4949dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4948data.bed",
+        "polyedge": "MSH2",
+    },
+    "Pan4132": {  # VCP3 R56 (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4362",
+        "congenica_project": "5092",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+    },
+    "Pan4134": {  # VCP3 R57 (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4362",
+        "congenica_project": "5092",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+    },
+    "Pan4136": {  # VCP3 R58 (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4362",
+        "congenica_project": "5092",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+    },
+    "Pan4137": {  # VCP3 R60 (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4362",
+        "congenica_project": "5092",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+    },
+    "Pan4138": {  # VCP3 R62 (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4362",
+        "congenica_project": "5092",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+    },
+    "Pan4143": {  # VCP3 R66 (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4362",
+        "congenica_project": "5092",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+    },
+    "Pan4144": {  # VCP3 R78 (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4362",
+        "congenica_project": "5092",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+    },
+    "Pan4145": {  # VCP3 R79 - CMD (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4362",
+        "congenica_project": "4666",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+    },
+    "Pan4146": {  # VCP3 R81 CM (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4362",
+        "congenica_project": "4666",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+    },
+    "Pan4151": {  # VCP3 R82 limb girdle (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4362",
+        "congenica_project": "5092",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+    },
+    "Pan4351": {  # VCP3 R227 (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4362",
+        "congenica_project": "5522",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+    },
+    "Pan4387": {  # VCP3 R90 Bleeding and platelet disorders (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4362",
+        "congenica_project": "4699",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+    },
+    "Pan4390": {  # VCP3 R97 Thrombophilia with a likely monogenic cause (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4362",
+        "congenica_project": "4699",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+    },
+    "Pan4314": {  # VCP3 R229 (Viapath)
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4362",
+        "congenica_project": "5290",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+    },
+    "Pan4396": {  # ArcherDx (Synnovis)
+        "archerdx": True,
+        "congenica_upload": False,
+    },
+    "Pan5113": {  # ArcherDx (BSPS)
+        "archerdx": True,
+        "congenica_upload": False,
+    },
+    "Pan5115": {  # ArcherDx (Control)
+        "archerdx": True,
+        "congenica_upload": False,
+    },
+    "Pan4574": {  # somatic VCP2 M1.2
+        "mokacan": True,
+        "congenica_upload": False,
+        "variant_calling_bedfile": "Pan4577data.bed",
+        "hsmetrics_bedfile": "Pan4949data.bed",
+        "clinical_coverage_depth": 200,
+    },
+    "Pan4579": {  # somatic VCP2 M1.1
+        "mokacan": True,
+        "congenica_upload": False,
+        "variant_calling_bedfile": "Pan4578data.bed",
+        "hsmetrics_bedfile": "Pan4949data.bed",
+        "clinical_coverage_depth": 200,
+    },
+    "Pan4969": {  # TSO500 no UTRs. TERT promoter
+        "TSO500": True,
+        "sambamba_bedfile": "Pan4969dataSambamba.bed",  # NOTE All TSO500 output parser settings are currently taken from the first pan number listed in tso500_panel_list
+        "clinical_coverage_depth": 100,
+        "multiqc_coverage_level": 100,
+        "coverage_min_basecall_qual": 25,
+        "coverage_min_mapping_qual": 30,
+    },
+    "Pan5085": {  # TSO500 High throughput Synnovis. no UTRs. TERT promoter
+        "TSO500": True,
+        "TSO500_high_throughput": True,
+        "sambamba_bedfile": "Pan4969dataSambamba.bed",  # NOTE All TSO500 output parser settings are currently taken from the first pan number listed in tso500_panel_list
+        "clinical_coverage_depth": 100,
+        "multiqc_coverage_level": 100,
+        "coverage_min_basecall_qual": 25,
+        "coverage_min_mapping_qual": 30,
+    },
+    "Pan5112": {  # TSO500 High throughput BSPS. no UTRs. TERT promoter
+        "TSO500": True,
+        "TSO500_high_throughput": True,
+        "sambamba_bedfile": "Pan4969dataSambamba.bed",  # NOTE All TSO500 output parser settings are currently taken from the first pan number listed in tso500_panel_list
+        "clinical_coverage_depth": 100,
+        "multiqc_coverage_level": 100,
+        "coverage_min_basecall_qual": 25,
+        "coverage_min_mapping_qual": 30,
+        "drylab_dnanexus_id": "BSPS_MD",
+    },
+    "Pan5114": {  # TSO500 High throughput Control. no UTRs. TERT promoter
+        "TSO500": True,
+        "TSO500_high_throughput": True,
+        "sambamba_bedfile": "Pan4969dataSambamba.bed",  # NOTE All TSO500 output parser settings are currently taken from the first pan number listed in tso500_panel_list
+        "clinical_coverage_depth": 100,
+        "multiqc_coverage_level": 100,
+        "coverage_min_basecall_qual": 25,
+        "coverage_min_mapping_qual": 30,
+        "drylab_dnanexus_id": "BSPS_MD",
+    },
+    "Pan4821": {  # VCP1 STG R134_FH
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4203",
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "STG": True,
+        "FH": True,
+    },
+    "Pan4822": {  # VCP1 STG R184_CF
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4203",
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "STG": True,
+    },
+    "Pan4823": {  # VCP1 STG R25_FGFR
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4203",
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "STG": True,
+    },
+    "Pan4824": {  # VCP1 STG R73_DMD
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4203",
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "STG": True,
+    },
+    "Pan4825": {  # VCP1 STG R337_cadasil
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan4399",
+        "RPKM_also_analyse": vcp1_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4203",
+        "hsmetrics_bedfile": "Pan4397data.bed",
+        "variant_calling_bedfile": "Pan4398data.bed",
+        "sambamba_bedfile": "Pan4397dataSambamba.bed",
+        "STG": True,
+    },
+    "Pan4826": {  # VCP3 STG R56
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3974",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4201",
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+    },
+    "Pan4827": {  # VCP3 STG R57
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3974",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4201",
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+    },
+    "Pan4828": {  # VCP3 STG R58
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3974",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4201",
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+    },
+    "Pan4829": {  # VCP3 STG R60
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3974",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4201",
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+    },
+    "Pan4830": {  # VCP3 STG R62
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3974",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4201",
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+    },
+    "Pan4831": {  # VCP3 STG R66
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3974",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4201",
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+    },
+    "Pan4832": {  # VCP3 STG R78
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3974",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4201",
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+    },
+    "Pan4833": {  # VCP3 STG R79
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3974",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4201",
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+    },
+    "Pan4834": {  # VCP3 STG R81
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3974",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4201",
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+    },
+    "Pan4835": {  # VCP3 STG R82
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3974",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4201",
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+    },
+    "Pan4836": {  # VCP3 STG R229
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3974",
+        "RPKM_also_analyse": vcp3_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4201",
+        "hsmetrics_bedfile": "Pan4995data.bed",
+        "variant_calling_bedfile": "Pan4995data.bed",
+        "sambamba_bedfile": "Pan4995dataSambamba.bed",
+    },
+    "Pan4818": {  # VCP2 STG R209
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3614",
+        "RPKM_also_analyse": vcp2_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4202",
+        "hsmetrics_bedfile": "Pan4949data.bed",
+        "variant_calling_bedfile": "Pan4948data.bed",
+        "sambamba_bedfile": "Pan4949dataSambamba.bed",
+    },
+    "Pan4819": {  # VCP2 STG R210
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3614",
+        "RPKM_also_analyse": vcp2_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4202",
+        "hsmetrics_bedfile": "Pan4949data.bed",
+        "variant_calling_bedfile": "Pan4948data.bed",
+        "sambamba_bedfile": "Pan4949dataSambamba.bed",
+        "polyedge": "MSH2",
+    },
+    "Pan4820": {  # VCP2 STG R211
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3614",
+        "RPKM_also_analyse": vcp2_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "4202",
+        "hsmetrics_bedfile": "Pan4949data.bed",
+        "variant_calling_bedfile": "Pan4948data.bed",
+        "sambamba_bedfile": "Pan4949dataSambamba.bed",
+        "polyedge": "MSH2",
+    },
+    "Pan4816": {  # VCP2 STG R208
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3614",
+        "RPKM_also_analyse": vcp2_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "1099",
+        "hsmetrics_bedfile": "Pan4949data.bed",
+        "variant_calling_bedfile": "Pan4948data.bed",
+        "sambamba_bedfile": "Pan4949dataSambamba.bed",
+    },
+    "Pan4817": {  # VCP2 STG R207
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "RPKM_bedfile_pan_number": "Pan3614",
+        "RPKM_also_analyse": vcp2_panel_list,
+        "congenica_credentials": "STG",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "1099",
+        "hsmetrics_bedfile": "Pan4949data.bed",
+        "variant_calling_bedfile": "Pan4948data.bed",
+        "sambamba_bedfile": "Pan4949dataSambamba.bed",
+        "polyedge": "MSH2",
+    },
+    "Pan5007": {  # LRPCR Via R207 PMS2
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "capture_type": "Amplicon",
+        "congenica_IR_template": "priority",
+        "congenica_project": "9986",
+        "hsmetrics_bedfile": "Pan4967_reference.bed",  # LRPCR amplicon BED file
+        "variant_calling_bedfile": "Pan4767data.bed",
+        "sambamba_bedfile": "Pan5018dataSambamba.bed",
+        "masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q",  # hs37d5_Pan4967.bwa-index.tar.gz
+    },
+    "Pan5008": {  # LRPCR STG R207 PMS2
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "capture_type": "Amplicon",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "10010",
+        "congenica_credentials": "STG",
+        "hsmetrics_bedfile": "Pan4967_reference.bed",  # LRPCR amplicon BED file
+        "variant_calling_bedfile": "Pan4767data.bed",
+        "sambamba_bedfile": "Pan5018dataSambamba.bed",
+        "masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q",  # hs37d5_Pan4967.bwa-index.tar.gz
+    },
+    "Pan5011": {  # LRPCR Via R210 PMS2
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "capture_type": "Amplicon",
+        "congenica_IR_template": "priority",
+        "congenica_project": "9981",
+        "hsmetrics_bedfile": "Pan4967_reference.bed",  # LRPCR amplicon BED file
+        "variant_calling_bedfile": "Pan4767data.bed",
+        "sambamba_bedfile": "Pan5018dataSambamba.bed",
+        "masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q",  # hs37d5_Pan4967.bwa-index.tar.gz
+    },
+    "Pan5012": {  # LRPCR STG R210 PMS2
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "capture_type": "Amplicon",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "10042",
+        "congenica_credentials": "STG",
+        "hsmetrics_bedfile": "Pan4967_reference.bed",  # LRPCR amplicon BED file
+        "variant_calling_bedfile": "Pan4767data.bed",
+        "sambamba_bedfile": "Pan5018dataSambamba.bed",
+        "masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q",  # hs37d5_Pan4967.bwa-index.tar.gz
+    },
+    "Pan5013": {  # LRPCR Via R211 PMS2
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "capture_type": "Amplicon",
+        "congenica_IR_template": "priority",
+        "congenica_project": "9982",
+        "hsmetrics_bedfile": "Pan4967_reference.bed",  # LRPCR amplicon BED file
+        "variant_calling_bedfile": "Pan4767data.bed",
+        "sambamba_bedfile": "Pan5018dataSambamba.bed",
+        "masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q",  # hs37d5_Pan4967.bwa-index.tar.gz
+    },
+    "Pan5014": {  # LRPCR STG R211 PMS2
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "capture_type": "Amplicon",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "10042",
+        "congenica_credentials": "STG",
+        "hsmetrics_bedfile": "Pan4967_reference.bed",  # LRPCR amplicon BED file
+        "variant_calling_bedfile": "Pan4767data.bed",
+        "sambamba_bedfile": "Pan5018dataSambamba.bed",
+        "masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q",  # hs37d5_Pan4967.bwa-index.tar.gz
+    },
+    "Pan5009": {  # LRPCR Via R208 CHEK2
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "capture_type": "Amplicon",
+        "congenica_IR_template": "priority",
+        "congenica_project": "9984",
+        "hsmetrics_bedfile": "Pan4967_reference.bed",  # LRPCR amplicon BED file
+        "variant_calling_bedfile": "Pan4767data.bed",
+        "sambamba_bedfile": "Pan5018dataSambamba.bed",
+        "masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q",  # hs37d5_Pan4967.bwa-index.tar.gz
+    },
+    "Pan5010": {  # LRPCR STG R208 CHEK2
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "capture_type": "Amplicon",
+        "congenica_IR_template": "non-priority",
+        "congenica_project": "10009",
+        "congenica_credentials": "STG",
+        "hsmetrics_bedfile": "Pan4967_reference.bed",  # LRPCR amplicon BED file
+        "variant_calling_bedfile": "Pan4766data.bed",
+        "sambamba_bedfile": "Pan5018dataSambamba.bed",
+        "masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q",  # hs37d5_Pan4967.bwa-index.tar.gz
+    },
+    "Pan5015": {  # LRPCR Via R71 SMN1
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "capture_type": "Amplicon",
+        "congenica_IR_template": "non-priority",  # TODO
+        "congenica_project": "9547",  # TODO
+        "hsmetrics_bedfile": "Pan4967_reference.bed",  # LRPCR amplicon BED file
+        "variant_calling_bedfile": "Pan4971data.bed",
+        "sambamba_bedfile": "Pan5018dataSambamba.bed",
+        "masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q",  # hs37d5_Pan4967.bwa-index.tar.gz
+    },
+    "Pan5016": {  # LRPCR Via R239 IKBKG
+        "mokapipe": True,
+        "multiqc_coverage_level": 30,
+        "capture_type": "Amplicon",
+        "congenica_IR_template": "priority",
+        "congenica_project": "9985",
+        "hsmetrics_bedfile": "Pan4967_reference.bed",  # LRPCR amplicon BED file
+        "variant_calling_bedfile": "Pan4768data.bed",
+        "sambamba_bedfile": "Pan5018dataSambamba.bed",
+        "masked_reference": "project-ByfFPz00jy1fk6PjpZ95F27J:file-GF84GF00QfBfzV35Gf8Qg53q",  # hs37d5_Pan4967.bwa-index.tar.gz
+    },
 }
-
 
 
 # =================turnaround time
@@ -1436,12 +1602,16 @@ panel_settings = {
 allowed_time_for_tasks = 4
 
 # =================== Email server settings
-username_file_path = "{document_root}/.amazon_email_username".format(document_root=document_root)
+username_file_path = "{document_root}/.amazon_email_username".format(
+    document_root=document_root
+)
 with open(username_file_path, "r") as username_file:
-	user = username_file.readline().rstrip()
-pw_file = "{document_root}/.amazon_email_pw".format(document_root=document_root)
+    user = username_file.readline().rstrip()
+pw_file = "{document_root}/.amazon_email_pw".format(
+    document_root=document_root
+)
 with open(pw_file, "r") as email_password_file:
-	pw = email_password_file.readline().rstrip()
+    pw = email_password_file.readline().rstrip()
 host = "email-smtp.eu-west-1.amazonaws.com"
 port = 587
 me = "moka.alerts@gstt.nhs.uk"
@@ -1449,9 +1619,9 @@ you = mokaguys_email
 oncology_you = oncology_ops_email
 smtp_do_tls = True
 if testing:
-	test_email_header = "AUTOMATED SCRIPTS ARE BEING RUN IN TEST MODE. PLEASE IGNORE THIS EMAIL\n\n"
+    test_email_header = "AUTOMATED SCRIPTS ARE BEING RUN IN TEST MODE. PLEASE IGNORE THIS EMAIL\n\n"
 else:
-	test_email_header = ""
+    test_email_header = ""
 
 
 # ================ Integrity check
@@ -1463,22 +1633,44 @@ checksum_complete_flag = "Checksum result reported"
 checksum_match = "Checksums match"
 
 # ================ cluster density calculation
-cluster_density_success_statement = "picard.illumina.CollectIlluminaLaneMetrics done"
+cluster_density_success_statement = (
+    "picard.illumina.CollectIlluminaLaneMetrics done"
+)
 cluster_density_error_statement = "PicardException"
 cluster_density_file_suffix = ".illumina_lane_metrics"
 phasing_metrics_file_suffix = ".illumina_phasing_metrics"
 novaseq_id = "A01229"
 
 # ================ demultiplexing
-demultiplex_success_match = r".*Processing completed with 0 errors and 0 warnings.$"
-demultiplexing_log_file_TSO500_message = "TSO500 run. Does not need demultiplexing locally"
+demultiplex_success_match = (
+    r".*Processing completed with 0 errors and 0 warnings.$"
+)
+demultiplexing_log_file_TSO500_message = (
+    "TSO500 run. Does not need demultiplexing locally"
+)
 # list of sequencers which require md5 checksums from integrity check to be assessed
 sequencers_with_integrity_check = ["NB551068", "NB552085", novaseq_id]
 bcl2fastq_stats_filename = "Stats.json"
-bcl2fastq_stats_path = os.path.join(fastq_folder,"Stats")
+bcl2fastq_stats_path = os.path.join(fastq_folder, "Stats")
 
-polyedge_inputs = {"MSH2":
-					{"chrom": 2,
-					"poly_start": 47641559,
-					"poly_end": 47641586,
-					}}
+polyedge_inputs = {
+    "MSH2": {
+        "chrom": 2,
+        "poly_start": 47641559,
+        "poly_end": 47641586,
+    }
+}
+
+duty_csv_id = (
+    "project-ByfFPz00jy1fk6PjpZ95F27J:applet-GQG5kvQ0jy1YxB6Bq4KggVq5"
+)
+duty_csv_inputs = {
+    "tso_pannumbers": "-itso_pannumbers=Pan4969,Pan5085,Pan5114 ",
+    "stg_pannumbers": (
+        "-istg_pannumbers=Pan4042,Pan4043,Pan4044,Pan4049,Pan4821,Pan4822,"
+        "Pan4823,Pan4824,Pan4825,Pan4816,Pan4817,Pan4818,Pan4819,Pan4820,"
+        "Pan4826,Pan4827,Pan4828,Pan4829,Pan4830,Pan4831,Pan4832,Pan4833,"
+        "Pan4834,Pan4835,Pan4836,Pan5008,Pan5010,Pan5012,Pan5014 "
+    ),
+    "cp_capture_pannos": "-icp_capture_pannos=Pan3614,Pan4399,Pan4362 ",
+}


### PR DESCRIPTION
This release contains several changes:
- The addition of the duty_csv app to the end of all workflows. This consists of the addition of a new function to create the dx run command in the same way as for multiqc, and addition of config variables containing the inputs
- Alteration to the way the TSO500 pipeline is set off so that it no longer requires use of the output parser app. This facilitates easier updating of the pipeline, and brings it closer to the set up of the other pipelines, with set off using the dx run command bash script which contains all run commands, as opposed to the commands being split between the workstation and DNAnexus
- Addition of the --wait flag to the tso docker run command, to delay downstream tasks until all output files have been created
- Update the version of fastqc used for ArcherDX and TSO samples

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/484)
<!-- Reviewable:end -->
