### PR TITLE
Feature/fix duty csv

### DIFF
--- a/automate_demultiplex_config.py
+++ b/automate_demultiplex_config.py
@@ -1637,7 +1637,7 @@ polyedge_inputs = {
 }
 
 duty_csv_id = (
-    "project-ByfFPz00jy1fk6PjpZ95F27J:applet-GQG5kvQ0jy1YxB6Bq4KggVq5"
+    "project-ByfFPz00jy1fk6PjpZ95F27J:applet-GQg9J280jy1Zf79KGx9gk5K3"
 )
 duty_csv_inputs = {
     # tso_pannumbers should not include the dry lab pan number

--- a/upload_and_setoff_workflows.py
+++ b/upload_and_setoff_workflows.py
@@ -1375,7 +1375,7 @@ class RunfolderProcessor(object):
 
         # loop through samples
         for fastq in self.list_of_processed_samples:
-            # Check if TSO500 sample
+            # Check if TSO sample using read 1 (TSO runs treated differently)
             if not re.search(r"_R1_", fastq) and fastq.startswith("TSO"):
                 # extract Pan number and use this to determine which dx run commands are needed for the sample
                 panel = re.search(r"Pan\d+", fastq).group()
@@ -1383,7 +1383,7 @@ class RunfolderProcessor(object):
                 if self.panel_dictionary[panel]["TSO500"]:
                     TSO500 = True
 
-            # take read one - note TSO500 sample list are not fastqs so are treated differently (elif below)
+            # If read 1 but not a not TSO500 sample
             elif re.search(r"_R1_", fastq):
                 # extract Pan number and use this to determine which dx run commands are needed for the sample
                 panel = re.search(r"Pan\d+", fastq).group()

--- a/upload_and_setoff_workflows.py
+++ b/upload_and_setoff_workflows.py
@@ -1488,6 +1488,7 @@ class RunfolderProcessor(object):
             # TODO if custom panels and WES done together currently no way
             # to stop custom panels being analysed by peddy - may cause problems
             commands_list.append(self.run_peddy_command())
+            commands_list.append(self.add_to_depends_list("peddy"))
 
         if TSO500:
             # build command for the TSO500 app

--- a/upload_and_setoff_workflows.py
+++ b/upload_and_setoff_workflows.py
@@ -1462,7 +1462,7 @@ class RunfolderProcessor(object):
 
                 if self.panel_dictionary[panel]["archerdx"]:
                     commands_list.append(
-                        self.create_fastqc_command(fastq, panel)
+                        self.create_fastqc_command(fastq)
                     )
                     commands_list.append(self.add_to_depends_list(fastq))
 
@@ -1493,7 +1493,7 @@ class RunfolderProcessor(object):
             for sample in self.list_of_processed_samples:
                 pannumber = re.search(r"Pan\d+", sample).group()
                 commands_list.append(
-                    self.create_fastqc_command(sample, pannumber)
+                    self.create_fastqc_command(sample)
                 )
                 commands_list.append(self.add_to_depends_list(sample))
                 if "HD200" in sample:
@@ -1514,7 +1514,9 @@ class RunfolderProcessor(object):
                 commands_list.append(
                     self.create_sambamba_cmd(sample, pannumber)
                     )
-                commands_list.append(self.add_to_depends_list(sample))
+                # Don't want to exclude negative controls from the depends list
+                # as we want a coverage report to help assess contamination
+                commands_list.append(self.add_to_depends_list("sambamba"))
 
         if rpkm_list:
             # Create a set of RPKM numbers for one command per panel
@@ -1572,7 +1574,7 @@ class RunfolderProcessor(object):
 
         return dx_command
 
-    def create_fastqc_command(self, fastqs, pannumber):
+    def create_fastqc_command(self, fastqs):
         """
         Build dx run command
         Inputs:


### PR DESCRIPTION
Fixes for the last update:
- New version of dnanexus_duty_csv (v1.1.0 - https://github.com/moka-guys/dnanexus_duty_csv/releases/tag/v1.1.0). This swaps the secrets file IDs to file names to allow these files to be updated with new tokens etc. without the need to update the app as well. It also incorporates the new duty_csv version (v2.1.0 - https://github.com/moka-guys/duty_csv/releases/tag/v2.1.0), which incorporates improved conditional formatting for test vs prod mode for the email instructions in the email HTML, and fixes the StG path formatting for run processing in production mode by the removal of an additional %s in the download path strings causing the files to download to a nested folder when being processed with process_duty_csv
- Re-add peddy to multiqc depends list (accidentally removed in the last release causing multiqc to run before peddy was complete therefore not being included in the multiqc report output)
- Order of app dependency is now correct again for TSO (multiqc no longer depends on sambamba chanjo. Sambamba chanjo is now only depended upon by duty_csv, so the files are included in the generated duty CSV.
- Order of app dependency is now correct again for Custom Panels (RPKM is now in the duty_csv depends list only, so the files are included in the duty CSV)
- Remove non-required panel argument to fastqc command creation function

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/490)
<!-- Reviewable:end -->
