### PR TITLE
Feature/exomedepth vcp3

### DIFF
--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -98,9 +98,9 @@ NEXUS_IDS = {
         "hs37d5_ref_with_index": f"{TOOLS_PROJECT}:file-ByYgX700b80gf4ZY1GxvF3Jv",  # hs37d5.fasta-index.tar.gz
         "hs37d5_ref_no_index": f"{TOOLS_PROJECT}:file-B6ZY7VG2J35Vfvpkj8y0KZ01",  # hs37d5.fa.gz
         "masked_reference": MASKED_REFERENCE,  # hs37d5_Pan4967.bwa-index.tar.gz
-        "ed_vcp1_readcount_normals": f"{TOOLS_PROJECT}:file-Gbv7Yb80v8Q40f8v140QBPQv",  # Pan5191_normals_v1.1.0.RData
+        "ed_vcp1_readcount_normals": f"{TOOLS_PROJECT}:file-GgKKP4Q01jZ62QgF2bbPqz78",  # Pan5208_normals_v1.0.0.RData
         "ed_vcp2_readcount_normals": f"{TOOLS_PROJECT}:file-Gbkgyq00ZpxpFKx03zVPJ9GX",  # Pan5188_normals_v1.1.0.RData
-        "ed_vcp3_readcount_normals": f"{TOOLS_PROJECT}:file-GbkY5v80jjgjkJqPXbgFpYzF",  # Pan5192_normals_v1.0.0.RData
+        "ed_vcp3_readcount_normals": f"{TOOLS_PROJECT}:file-Gj62x5804G8j5Vq90q712FP9",  # Pan5217_normals_v1.0.0.RData
         "sompy_truth_vcf": f"{TOOLS_PROJECT}:file-G7g9Pfj0jy1f87k1J1qqX83X",  # HD200_expectedsorted.vcf
     },
     "APPS": {

--- a/config/panel_config.py
+++ b/config/panel_config.py
@@ -122,7 +122,7 @@ class PanelConfig:
             "hsmetrics_bedfile": f"{BEDFILE_FOLDER}Pan4397data.bed",
             "sambamba_bedfile": f"{BEDFILE_FOLDER}Pan4397dataSambamba.bed",
             "variant_calling_bedfile": f"{BEDFILE_FOLDER}Pan4398data.bed",
-            "ed_readcount_bedfile": f"{BEDFILE_FOLDER}Pan5191_exomedepth.bed",
+            "ed_readcount_bedfile": f"{BEDFILE_FOLDER}Pan5208_exomedepth.bed",
             "rpkm_bedfile": f"{BEDFILE_FOLDER}Pan4399_RPKM.bed",
             "capture_type": "Hybridisation",
             "multiqc_coverage_level": 30,
@@ -158,7 +158,7 @@ class PanelConfig:
             "hsmetrics_bedfile": f"{BEDFILE_FOLDER}Pan4995data.bed",
             "sambamba_bedfile": f"{BEDFILE_FOLDER}Pan4995dataSambamba.bed",
             "variant_calling_bedfile": f"{BEDFILE_FOLDER}Pan4995data.bed",
-            "ed_readcount_bedfile": f"{BEDFILE_FOLDER}Pan5192_exomedepth.bed",
+            "ed_readcount_bedfile": f"{BEDFILE_FOLDER}Pan5217_exomedepth.bed",
             "rpkm_bedfile": f"{BEDFILE_FOLDER}Pan4362_RPKM.bed",
             "capture_type": "Hybridisation",
             "multiqc_coverage_level": 30,
@@ -366,7 +366,7 @@ class PanelConfig:
             "test_number": "R134",
             "congenica_project": 4664,
             "FH": True,
-            "ed_cnvcalling_bedfile": "Pan4702",
+            "ed_cnvcalling_bedfile": "Pan5215",
         },
         "Pan4121": {  # VCP1 R184 (Synnovis) - Cystic Fibrosis
             **CAPTURE_PANEL_DICT["vcp1"],
@@ -475,10 +475,10 @@ class PanelConfig:
         "Pan4821": {  # VCP1 R134 (STG) - FH
             **CAPTURE_PANEL_DICT["vcp1"],
             **CONGENICA_CREDENTIALS["stg"],
-            "test_number": "R13",
+            "test_number": "R134",
             "congenica_project": 4203,
             "FH": True,
-            "ed_cnvcalling_bedfile": "Pan4702",
+            "ed_cnvcalling_bedfile": "Pan5215",
         },
         "Pan4822": {  # VCP1 R184 (STG) - CF
             **CAPTURE_PANEL_DICT["vcp1"],
@@ -638,7 +638,7 @@ class PanelConfig:
             **CONGENICA_CREDENTIALS["synnovis"],
             "test_number": "R79",
             "congenica_project": 4666,
-            "ed_cnvcalling_bedfile": "Pan5168",
+            "ed_cnvcalling_bedfile": "Pan5220",
         },
         "Pan4146": {  # VCP3 R81 (Synnovis) - Congenital myopathy
             **CAPTURE_PANEL_DICT["vcp3"],
@@ -718,7 +718,7 @@ class PanelConfig:
             **CONGENICA_CREDENTIALS["synnovis"],
             "test_number": "R90",
             "congenica_project": 4699,
-            "ed_cnvcalling_bedfile": "Pan5171",
+            "ed_cnvcalling_bedfile": "Pan5223",
         },
         "Pan4390": {  # VCP3 R97 (Synnovis) - Thrombophilia with a likely monogenic cause
             **CAPTURE_PANEL_DICT["vcp3"],
@@ -775,7 +775,7 @@ class PanelConfig:
             **CONGENICA_CREDENTIALS["stg"],
             "test_number": "R79",
             "congenica_project": 4201,
-            "ed_cnvcalling_bedfile": "Pan5168",
+            "ed_cnvcalling_bedfile": "Pan5220",
         },
         "Pan4834": {  # VCP3 R81 (STG) - Congenital myopathy
             **CAPTURE_PANEL_DICT["vcp3"],


### PR DESCRIPTION
- Updated readcount bedfiles for VCP1 and VCP3, there are required for the first app of exomdepth.
- Updated the normals files (Rdata) for VCP1 and VCP3, new panel of normals made using the new readcount bedfile
- Made new CNV calling bedfiles for R134 (includes additional genes), R79(remade to fix single exon issue), R90(remade to fix single exon issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/535)
<!-- Reviewable:end -->
