### PR TITLE
Re add coverage back to tso postprocessing commands

### DIFF
--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -2013,7 +2013,7 @@ class BuildDxCommands(SWConfig):
                 self.samples_obj.samples_dict[sample_name]["sample_pipeline_cmd"]
             )
             dx_postprocessing_cmds.append(SWConfig.UPLOAD_ARGS["depends_list"])
-            sambamba_cmds_list.append(
+            dx_postprocessing_cmds.append(
                 self.create_sambamba_cmd(
                     sample_name, self.samples_obj.samples_dict[sample_name]["pannum"]
                 )


### PR DESCRIPTION
Coverage accidentally removed from commands list for tso500 so is readded here

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/538)
<!-- Reviewable:end -->
