### PR TITLE
Add duty_csv to automated scripts for dev runs

### DIFF
--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -851,6 +851,7 @@ class DevPipeline:
         self.workflow_cmds.extend(
             self.rf_cmds_obj.return_multiqc_cmds(self.rf_samples_obj.pipeline)
         )
+        self.workflow_cmds.append(self.rf_cmds_obj.create_duty_csv_cmd())
 
 
 class ArcherDxPipeline:


### PR DESCRIPTION
- Add missing duty_csv command for dev runs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/552)
<!-- Reviewable:end -->
