### PR TITLE
Fastq validation checks

### DIFF
--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -388,12 +388,12 @@ class DemultiplexConfig(PanelConfig):
         "--RUN_DIRECTORY /input_run --OUTPUT_DIRECTORY /input_run --OUTPUT_PREFIX %s"
     )
     ADX_CMD = (
-        f"docker run \
-            -v {RUNFOLDERS}/${{run_folder_name}}/Data/Intensities/BaseCalls:/data \
-            -v {DOCUMENT_ROOT}:/auth_file \
-            {ARCHER_DOCKER}  /data \
-            auth_file/{CREDENTIALS['adx_authtoken']} \
-            ${{job_name}} 2 | tee -a {AD_LOGDIR}/archer_api_upload_logfiles/${{run_folder_name}}_archer_api_logfile.txt"
+        f"docker run "
+        f"-v {RUNFOLDERS}/${{run_folder_name}}/Data/Intensities/BaseCalls:/data "
+        f"-v {DOCUMENT_ROOT}:/auth_file "
+        f"{ARCHER_DOCKER} /data "
+        f"auth_file/{CREDENTIALS['adx_authtoken']} "
+        f"${{job_name}} 2 | tee -a {AD_LOGDIR}/archer_api_upload_logfiles/${{run_folder_name}}_archer_api_logfile.txt"
     )
     DEMULTIPLEX_TEST_RUNFOLDERS = [
         "999999_NB552085_0496_DEMUXINTEG",

--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -392,7 +392,7 @@ class DemultiplexConfig(PanelConfig):
             -v {RUNFOLDERS}/${{run_folder_name}}/Data/Intensities/BaseCalls:/data \
             -v {DOCUMENT_ROOT}:/auth_file \
             {ARCHER_DOCKER}  /data \
-            auth_file/{CREDENTIALS["adx_authtoken"]} \
+            auth_file/{CREDENTIALS['adx_authtoken']} \
             ${{job_name}} 2 | tee -a {AD_LOGDIR}/archer_api_upload_logfiles/${{run_folder_name}}_archer_api_logfile.txt"
     )
     DEMULTIPLEX_TEST_RUNFOLDERS = [

--- a/demultiplex/README.md
+++ b/demultiplex/README.md
@@ -76,7 +76,7 @@ Logging is performed using [ad_logger](../ad_logger/ad_logger.py).
 | ------------------ | ------------------------------------------------------------------------------ | ----------------------------------------------------- | ---------------------------------------------------------------------------------- |
 | Demultiplex output | Catches any traceback from errors when running the cron job that are not caught by exception handling within the script | `TIMESTAMP.txt` | `/usr/local/src/mokaguys/automate_demultiplexing_logfiles/Demultiplex_cron_stdout` |
 | demultiplex (script_logger) | Records script-level logs for the demultiplex script | `TIMESTAMP_demultiplex_script.log` | `/usr/local/src/mokaguys/automate_demultiplexing_logfiles/demultiplexing_script_logfiles/` |
-| demultiplex (demux_rf_logger) | Records runfolder-level logs for the demultiplex script | `RUNFOLDERNAME_demultiplex_runfolder.log` | `/usr/local/src/mokaguys/automate_demultiplexing_logfiles/demultiplexing_script_logfiles/` |
+| demultiplex (demux_rf_logger) | Records runfolder-level logs including gzip validation results and FASTQ file structure checks | `RUNFOLDERNAME_demultiplex_runfolder.log` | `/usr/local/src/mokaguys/automate_demultiplexing_logfiles/demultiplexing_script_logfiles/` |
  Bcl2fastq output | STDERR from bcl2fastq2 | `bcl2fastq2_output.log` | Within the runfolder |
 
 ## Testing


### PR DESCRIPTION
1) Addition of simple fastq format checking, looking for:

- Malformed headers
- Insufficient lines (empty)
- Separator (+) symbol presence
- Sequence length match with quality length

Tested different tools (gztools, zcat,  for assessing for truncation at the end of the FASTQ file, but all methods require full gzip decompression (adding significant time to the process). 

After assessing truncated fastq.gz files by intentionally disrupting demultiplexing in a test run, I found that the gzip footer check still catches files where early truncation has occurred, so should be an adequate check in the majority of scenarios without requiring decompression.

2) Small fix to ADX_CMD in ad_config to use mismatched quotes in credentials dict to prevent early string termination, and removed backslashes to maintain f string consistency.

3) Small change to demux README.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/563)
<!-- Reviewable:end -->
