### PR TITLE
Integration of MSK run automation using Pan5236

### DIFF
--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -32,10 +32,8 @@ BRANCH = Repository(PROJECT_DIR).head.shorthand
 MAIL_SETTINGS = {
     "host": "email-smtp.eu-west-1.amazonaws.com",
     "port": 587,
-    #"binfx_email": "gst-tr.mokaguys@nhs.net",
-    "binfx_email": "gdoyle046@gmail.com",
-    #"alerts_email": "moka.alerts@gstt.nhs.uk",
-    "alerts_email": "gdoyle046@gmail.com",
+    "binfx_email": "gst-tr.mokaguys@nhs.net",
+    "alerts_email": "moka.alerts@gstt.nhs.uk",
 }
 
 if BRANCH == "main" and "pytest" not in sys.modules:  # Prod branch
@@ -399,7 +397,7 @@ class DemultiplexConfig(PanelConfig):
     )
     MSK_CMD = (
         f"python3 /usr/local/src/mokaguys/development_area/sophia_cli/sophia.py "
-        f"{RUNFOLDERS}/${{run_folder_name}} --qc-only"
+        f"{RUNFOLDERS}/${{run_folder_name}} --force"
     )
     DEMULTIPLEX_TEST_RUNFOLDERS = [
         "999999_NB552085_0496_DEMUXINTEG",

--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -396,7 +396,7 @@ class DemultiplexConfig(PanelConfig):
         f"${{job_name}} 2 | tee -a {AD_LOGDIR}/archer_api_upload_logfiles/${{run_folder_name}}_archer_api_logfile.txt"
     )
     MSK_CMD = (
-        f"python3 /usr/local/src/mokaguys/development_area/sophia_cli/sophia.py "
+        f"python3 /usr/local/src/mokaguys/sophia_cli/sophia.py "
         f"{RUNFOLDERS}/${{run_folder_name}} --force"
     )
     DEMULTIPLEX_TEST_RUNFOLDERS = [
@@ -486,7 +486,7 @@ class SWConfig(PanelConfig):
             "pipe": 5304,
             "wes": 5078,
             "archerdx": 5300,
-            "msk": 5236,
+            "msk": 5341,
             "snp": 5091,
             "tso500": 5301,
             "oncodeep": 5299,

--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -32,8 +32,10 @@ BRANCH = Repository(PROJECT_DIR).head.shorthand
 MAIL_SETTINGS = {
     "host": "email-smtp.eu-west-1.amazonaws.com",
     "port": 587,
-    "binfx_email": "gst-tr.mokaguys@nhs.net",
-    "alerts_email": "moka.alerts@gstt.nhs.uk",
+    #"binfx_email": "gst-tr.mokaguys@nhs.net",
+    "binfx_email": "gdoyle046@gmail.com",
+    #"alerts_email": "moka.alerts@gstt.nhs.uk",
+    "alerts_email": "gdoyle046@gmail.com",
 }
 
 if BRANCH == "main" and "pytest" not in sys.modules:  # Prod branch
@@ -395,6 +397,10 @@ class DemultiplexConfig(PanelConfig):
         f"auth_file/{CREDENTIALS['adx_authtoken']} "
         f"${{job_name}} 2 | tee -a {AD_LOGDIR}/archer_api_upload_logfiles/${{run_folder_name}}_archer_api_logfile.txt"
     )
+    MSK_CMD = (
+        f"python3 /usr/local/src/mokaguys/development_area/sophia_cli/sophia.py "
+        f"{RUNFOLDERS}/${{run_folder_name}} --qc-only"
+    )
     DEMULTIPLEX_TEST_RUNFOLDERS = [
         "999999_NB552085_0496_DEMUXINTEG",
         "999999_M02353_0496_000000000-DEMUX",
@@ -482,6 +488,7 @@ class SWConfig(PanelConfig):
             "pipe": 5304,
             "wes": 5078,
             "archerdx": 5300,
+            "msk": 5236,
             "snp": 5091,
             "tso500": 5301,
             "oncodeep": 5299,

--- a/config/panel_config.py
+++ b/config/panel_config.py
@@ -302,7 +302,7 @@ class PanelConfig:
         "Pan5226": {  # OncoDEEP
             **CAPTURE_PANEL_DICT["oncodeep"],
         },
-        "Pan5236": {  # OncoDEEP
+        "Pan5236": {  # MSK
             **CAPTURE_PANEL_DICT["msk"],
         },
         "Pan5085": {  # TSO500 High throughput Synnovis. no UTRs. TERT promoter

--- a/config/panel_config.py
+++ b/config/panel_config.py
@@ -227,6 +227,15 @@ class PanelConfig:
             "capture_type": "Hybridisation",
             "multiqc_coverage_level": 30,  # We don't align for Archer
         },
+        "msk": {
+            **DEFAULT_DICT,
+            "panel_name": "msk",
+            "pipeline": "msk",
+            "sample_prefix": "MSK",
+            "runtype": "MSK",
+            "capture_type": "Hybridisation",
+            "multiqc_coverage_level": 30,  # We don't align for MSK
+        },
         "tso500": {
             **DEFAULT_DICT,
             "panel_name": "tso500",
@@ -292,6 +301,9 @@ class PanelConfig:
         ),
         "Pan5226": {  # OncoDEEP
             **CAPTURE_PANEL_DICT["oncodeep"],
+        },
+        "Pan5236": {  # OncoDEEP
+            **CAPTURE_PANEL_DICT["msk"],
         },
         "Pan5085": {  # TSO500 High throughput Synnovis. no UTRs. TERT promoter
             **CAPTURE_PANEL_DICT["tso500"],
@@ -847,6 +859,7 @@ class PanelConfig:
     SNP_PANELS = [k for k, v in PANEL_DICT.items() if v["pipeline"] == "snp"]
     ARCHER_PANELS = [k for k, v in PANEL_DICT.items() if v["pipeline"] == "archerdx"]
     ONCODEEP_PANELS = [k for k, v in PANEL_DICT.items() if v["pipeline"] == "oncodeep"]
+    MSK_PANELS = [k for k, v in PANEL_DICT.items() if v["pipeline"] == "msk"]
     LRPCR_PANELS = [k for k, v in PANEL_DICT.items() if v["panel_name"] == "lrpcr"]
     DEV_PANEL = [k for k, v in PANEL_DICT.items() if v["runtype"] == "dev"]
     UMI_DEV_PANEL = [k for k, v in PANEL_DICT.items() if v["umis"] == True]

--- a/toolbox/toolbox.py
+++ b/toolbox/toolbox.py
@@ -1125,7 +1125,7 @@ class SampleObject(ToolboxConfig):
             # Extract the dna number from sample name
             primary_identifier = self.sample_name.split("_")[2]
             secondary_identifier = False  # Secondary identifiers are not input to Moka
-        elif self.pipeline in ("tso500", "archerdx", "oncodeep"):
+        elif self.pipeline in ("tso500", "archerdx", "oncodeep", "msk"):
             # Collect 3rd and 4th elements (identifiers)
             primary_identifier, secondary_identifier = self.sample_name.split("_")[2:4]
             # Negative and positive controls only have one ID so set id2 to null


### PR DESCRIPTION
Adding automation functionality for MSK runs:

- Added check to skip duty_csv commands for these runtypes
- Uses the custom sophia_cli Python automation script as a subprocess (due to issues with inheriting cached log-in data associated with the Sophia CLI platform and requirements to log in manually periodically, Dockerisation of the script was deemed less suitable for this case)
- Added config details for assigned Pan5236
- sophia.py script modified to handle directories appropriately (uses absolute filepaths opposed to relative) to allow subprocess execution from the automate_demultiplex directory

Testing was undertaken on the Turing workstation using run MSK25004. Demultiplex, upload, and workflow set-off stages completed successfully with appropriate logging stored in both test and production modes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/566)
<!-- Reviewable:end -->
