### PR TITLE
Aviti setoff_workflows Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The above image describes the possible associations in the Class Diagram. In the
 | Demultiplex output | Catches any traceback from errors when running the cron job that are not caught by exception handling within the script | `TIMESTAMP.txt` | `/usr/local/src/mokaguys/automate_demultiplexing_logfiles/Demultiplexing_stdout` |
 | demultiplex (script_logger) | Records script-level logs for the demultiplex script | `TIMESTAMP_demultiplex_script.log` | `/usr/local/src/mokaguys/automate_demultiplexing_logfiles/demultiplexing_script_logfiles/` |
 | demultiplex (demux_rf_logger) | Records runfolder-level logs for the demultiplex script | `RUNFOLDERNAME_demultiplex_runfolder.log` | `/usr/local/src/mokaguys/automate_demultiplexing_logfiles/demultiplexing_script_logfiles/` |
- Bcl2fastq output | STDOUT and STDERR from bcl2fastq2 | `bcl2fastq2_output.log` | Within the runfolder |
+ Demultiplex output | STDOUT and STDERR from bclconvert or bases2fastq based on sequencer used | `bclconvert_output.log`/ `bases2fastq_output.log` | Within the runfolder |
 | ss_validator | Records runfolder-level logs for the samplesheet_validator script | `RUNFOLDERNAME_samplesheet_validator_script.log` | `/usr/local/src/mokaguys/automate_demultiplexing_logfiles/samplesheet_validator_script_logfiles/` |
 | backup | Records the logs from the upload runfolder script | `RUNFOLDERNAME_upload_runfolder.log` | `/usr/local/src/mokaguys/automate_demultiplexing_logfiles/upload_runfolder_script_logfiles/` |
 | wscleaner | Records the logs from the wscleaner script | `TIMESTAMP_wscleaner.log` | `/usr/local/src/mokaguys/automate_demultiplexing_logfiles/wscleaner/` |

--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -34,7 +34,6 @@ MAIL_SETTINGS = {
     "port": 587,
     "binfx_email": "gst-tr.mokaguys@nhs.net",
     "alerts_email": "moka.alerts@gstt.nhs.uk",
-    "personal_email": "kieron.millard1@nhs.net"
 }
 
 if BRANCH == "main" and "pytest" not in sys.modules:  # Prod branch
@@ -70,10 +69,10 @@ else:  # Testing branch
     AD_LOGDIR = os.path.join(RUNFOLDERS, "automate_demultiplexing_logfiles")
     MAIL_SETTINGS = MAIL_SETTINGS | {  # Add test mail recipients
         "pipeline_started_subj": f"{SCRIPT_MODE}. ALERT: Started pipeline for %s",
-        "binfx_recipient": MAIL_SETTINGS["personal_email"],
+        "binfx_recipient": MAIL_SETTINGS["binfx_email"],
         # Oncology email address for email alerts
-        "oncology_ops_email": MAIL_SETTINGS["personal_email"],
-        "wes_samplename_emaillist": MAIL_SETTINGS["personal_email"],
+        "oncology_ops_email": MAIL_SETTINGS["binfx_email"],
+        "wes_samplename_emaillist": MAIL_SETTINGS["binfx_email"],
     }
 
 CREDENTIALS = {

--- a/config/log_msgs_config.py
+++ b/config/log_msgs_config.py
@@ -123,7 +123,7 @@ LOG_MSGS = {
         "demux_complete": "Run has been previously successfully processed by the demultiplexing script",
         "success_string_absent": "Run has previously been demultiplexed but no success string is present",
         "not_yet_demultiplexed": "Demultiplexing has not been performed",
-        "bcl2fastqlog_empty": "Bcl2fastq log file exists but is empty",
+        "demultiplexlog_empty": "Demultiplex log file exists but is empty",
         "nonexistent_files": "Not all files exist: %s",
         "view_users": "Users identifed that require VIEW project permissions: %s",
         "admin_users": "Users identifed that require ADMINISTER project permissions: %s",

--- a/setoff_workflows/README.md
+++ b/setoff_workflows/README.md
@@ -19,7 +19,7 @@ The module uses various functions and classes from the [Toolbox module](../toolb
 ## Protocol
 
 1. Identify runfolders in the runfolders directory which have not been processed:
-    - Runfolder contains bcl2fastq2 log file with success string
+    - Runfolder contains bcl2fastq2 or bases2fastq log file with success string
     - Runfolder does not contain upload started flag file (has not yet been uploaded to DNAnexus)
 2. Collect names and metadata for all samples in the runfolder, using the RunfolderSamples() class from the [Toolbox module](../toolbox/toolbox.py).
 3. Write and run the DNAnexus project creation script

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -789,9 +789,9 @@ class ProcessRunfolder(SWConfig):
         runfolder log file. If unsuccessful, exit script
             :return None:
         """
-        # Build upload_runfolder.py commands, ignoring BCL files for Illumina runs and Bases zip files
-        # for AVITI runs
-        if self.rf_samples_obj.pipeline in ["tso500", "dev"]:
+        # Build upload_runfolder.py commands, ignoring BCL files for Illumina runs and Bases zip files, 
+        # Alignement, Filter and Location files for AVITI runs 
+        if self.rf_samples_obj.pipeline in ["tso500"]:
             ignore = ""  # Upload BCL files for tso500 and dev runs
         elif self.rf_samples_obj.sequencer_type == SWConfig.AVITI_ID:
             ignore = "/BaseCalls,/Alignment,/Filter,/Location"

--- a/toolbox/toolbox.py
+++ b/toolbox/toolbox.py
@@ -283,7 +283,7 @@ def get_demultiplexlog_file(sequencer_type: str, runfolderpath: str) -> str:
         )
     else:
         return os.path.join(
-            runfolderpath, ToolboxConfig.FLAG_FILES["bcl2fastqlog"]
+            runfolderpath, ToolboxConfig.FLAG_FILES["bclconvertlog"]
         )
 
 def get_fastq_dir_path(sequencer_type: str, runfolderpath: str) -> str:
@@ -511,7 +511,7 @@ class RunfolderObject(ToolboxConfig):
         demultiplexlog_file (str):              Demultiplex logfile path - bases2fastq/bcl2fastq (within runfolder)
         fastq_dir_path (str):                   Runfolder fastq directory path (within runfolder)
         upload_flagfile (str):                  Flag file denoting upload has begun (within runfolder)
-        bcl2fastqstats_file (str):              Bcl2fastq stats file (within runfolder)
+        bclconvertstats_file (str):             Bclconvert stats file (within runfolder)
         cluster_density_files (list):           List containing runfolder lane metrics
                                                 and phasing metrics file paths
         demultiplex_runfolder_logfile (str):    Runfolder demultiplex logfile (within logfiles dir)

--- a/toolbox/toolbox.py
+++ b/toolbox/toolbox.py
@@ -26,6 +26,7 @@ from config.ad_config import ToolboxConfig
 from ad_logger.ad_logger import RunfolderLoggers
 import gzip
 import zlib
+import json
 
 
 def get_credential(file: str) -> None:
@@ -192,16 +193,115 @@ def check_returncode(
         logger.error(logger.log_msgs["cmd_fail"], returncode, out, err)
         return out, err, returncode
 
-
-def get_runfolder_path(runfolder_name: str) -> str:
+def get_sequencer_type(runfolder_name: str) -> str:
     """
-    Return the path of the runfolder based on the runfolder_name input
+    Returns the ID of sequencer run was loaded to based on runfolder name
+        :param runfolder_name (str):    Runfolder name string
+        :return (str):                  Sequencer type string
+    """
+    if ToolboxConfig.AVITI_ID in runfolder_name:
+        return ToolboxConfig.AVITI_ID
+    else:
+        return ToolboxConfig.NOVASEQ_ID
+
+def get_runfolder_path(sequencer_type: str, runfolder_name: str) -> str:
+    """
+    Return the path of the runfolder based on the sequencer type
+        :param sequencer_type (str):    Sequencer type string
         :param runfolder_name (str):    Runfolder name string
         :return (str):                  Runfolder path
     """
-    return os.path.join(ToolboxConfig.RUNFOLDERS, runfolder_name)
+    if sequencer_type == ToolboxConfig.AVITI_ID:
+        return os.path.join(ToolboxConfig.AVITI_RUNFOLDER, runfolder_name)
+    else:
+        return os.path.join(ToolboxConfig.RUNFOLDERS, runfolder_name)
 
+def get_samplesheet_name(sequencer_type: str, runfolder_name: str,aviti_runparameters_file: str) -> str:
+    """
+    Return the name of the samplesheet based on sequencer type. If Illumina find runfolder_Samplesheet.csv
+    If AVITI, uses the RunParameters.json file to construct the samplesheet file name.
+        :param sequencer_type (str):            Sequencer type string
+        :param runfolder_name (str):            Runfolder name string
+        :param aviti_runparameters_file (str):  RunParameters.json file string  
+        :return (str):                          Samplesheet.csv string  
+    """
+    if sequencer_type == ToolboxConfig.AVITI_ID:
+        with open(aviti_runparameters_file, 'r') as file:
+            runparameters_json = json.load(file)
+            date = runparameters_json.get("Date").replace("-","")
+            amended_date = date[2:8]
+            instrument_name = runparameters_json.get("InstrumentName")
+            side = runparameters_json.get("Side")[-1]
+            flowcell = runparameters_json.get("FlowcellID")
+        return f"{amended_date}_{instrument_name}_{side}{flowcell}_SampleSheet.csv"
+    else:
+        return f"{runfolder_name}_SampleSheet.csv"
 
+def get_runcompletefile_path(sequencer_type: str, runfolderpath: str) -> str:
+    """
+    Return run complete file path based on seqeuncer used
+        :param sequencer_type           Sequencer type string
+        :param runfolderpath (str):     Runfolder path string
+        :return (str):                  RTAComplete.txt/RunUploaded.json path
+    """
+    if sequencer_type == ToolboxConfig.AVITI_ID:
+        return os.path.join(
+            runfolderpath, ToolboxConfig.FLAG_FILES["aviti_seq_complete"]
+        )
+    else:
+        return os.path.join(
+            runfolderpath, ToolboxConfig.FLAG_FILES["illumina_seq_complete"]
+        )
+    
+def get_samplesheet_path(sequencer_type: str,samplesheet_name: str) -> str:
+    """
+    Return tech team uploaded samplesheet filepath based on sequencer used - 
+    filepath necessary for Illumina runs but not AVITI 
+        :param sequencer_type           Sequencer type string
+        :param samplesheet_name (str):  Samplesheet name string
+        :return (str):                  Samplesheet file path
+    """
+    if sequencer_type == ToolboxConfig.AVITI_ID:
+        return os.path.join(
+            ToolboxConfig.AVITI_SAMPLESHEET, samplesheet_name
+        )
+    else:
+        return os.path.join(
+            ToolboxConfig.RUNFOLDERS, "samplesheets", samplesheet_name
+        )
+
+def get_demultiplexlog_file(sequencer_type: str, runfolderpath: str) -> str:
+    """
+    Returns name of demultiplex log file based on demultiplex tool needed
+        :param sequencer_type           Sequencer type string
+        :param runfolderpath (str):     Runfolder path string
+        :return (str):                  bcl2fastq/bases2fastq log file string
+    """
+    if sequencer_type == ToolboxConfig.AVITI_ID:
+        return os.path.join(
+            runfolderpath, ToolboxConfig.FLAG_FILES["bases2fastqlog"]
+        )
+    else:
+        return os.path.join(
+            runfolderpath, ToolboxConfig.FLAG_FILES["bcl2fastqlog"]
+        )
+
+def get_fastq_dir_path(sequencer_type: str, runfolderpath: str) -> str:
+    """
+    Returns filepath for fastqs for demultiplexing based on sequencer used
+        :param sequencer_type           Sequencer type string
+        :param runfolderpath (str):     Runfolder path string
+        :return (str):                  Fastq directory path string
+    """
+    if sequencer_type == ToolboxConfig.AVITI_ID:
+        return os.path.join(
+            runfolderpath, ToolboxConfig.FASTQ_DIRS["aviti_fastqs"]
+        )
+    else:
+        return os.path.join(
+            runfolderpath, ToolboxConfig.FASTQ_DIRS["illumina_fastqs"]
+        )
+            
 def test_upload_software(logger: logging.Logger) -> True:
     """
     Test the required software is installed and performing. If not, exit the script
@@ -220,7 +320,7 @@ def test_processing_software(logger: logging.Logger) -> Optional[bool]:
     and test_dx_toolkit functions
         :return True|None:  Return true if the tests all pass
     """
-    if test_programs("bcl2fastq2", logger) and test_programs(
+    if test_programs("bclconvert", logger) and test_programs(
         "gatk_collect_lane_metrics", logger
     ):
         return True
@@ -288,7 +388,7 @@ def get_samplename_dict(
     if os.path.exists(samplesheet_path):
         reversed_samplesheet = reversed(read_lines(samplesheet_path))
         for line in reversed_samplesheet:
-            if line.startswith("Sample_ID") or "[Data]" in line:
+            if line.startswith(("Sample_ID", "SampleName", "[Data],", "#",)):
                 break
             # Skip empty lines (check first element of the line, after splitting on comma)
             elif len(line.split(",")[0]) < 2:
@@ -357,7 +457,7 @@ def validate_fastq_gzip(file_path: str, logger: logging.Logger) -> Optional[bool
 def validate_fastqs(fastq_dir_path: str, logger: logging.Logger) -> Optional[bool]:
     """
     Validate the created fastqs in the BaseCalls directory and log success
-    or failure error message accordingly. If any failure, remove bcl2fastq log
+    or failure error message accordingly. If any failure, remove demultiplex log
     file to trigger re-demultiplex on next script run
         :param fastq_dir_path (str):    Runfolder fastq directory path (within runfolder)
         :param logger (logging.Logger): Logger
@@ -397,7 +497,9 @@ class RunfolderObject(ToolboxConfig):
         timestamp (str):                        Timestamp in the format str(f"{datetime.datetime.now():
                                                 %Y%m%d_%H%M%S}")
         runfolder_name (str):                   Runfolder name string
+        sequencer_type (str):                   Sequencer ID string
         runfolderpath (str):                    Path of runfolder on workstation
+        aviti_runparameters_file (str):         RunParameters.json path string for AVITI runs (within runfolder)
         samplesheet_name (str):                 Name of runfolder SampleSheet
         rtacompletefile_path (str):             Sequencing finished filepath (within runfolder)
         samplesheet_path (str):                 Path to SampleSheet in SampleSheets dir
@@ -406,7 +508,7 @@ class RunfolderObject(ToolboxConfig):
         initial_sscheck_flagfile_path (str):    initial Samplesheet check flag file path (within runfolder)
 
         sscheck_flagfile_path (str):            2nd attempt Samplesheet check flag file path (within runfolder)
-        bcl2fastqlog_file (str):                bcl2fastq2 logfile path (within runfolder)
+        demultiplexlog_file (str):              Demultiplex logfile path - bases2fastq/bcl2fastq (within runfolder)
         fastq_dir_path (str):                   Runfolder fastq directory path (within runfolder)
         upload_flagfile (str):                  Flag file denoting upload has begun (within runfolder)
         bcl2fastqstats_file (str):              Bcl2fastq stats file (within runfolder)
@@ -439,14 +541,14 @@ class RunfolderObject(ToolboxConfig):
         )
         self.timestamp = timestamp
         self.runfolder_name = runfolder_name
-        self.runfolderpath = get_runfolder_path(self.runfolder_name)
-        self.samplesheet_name = f"{self.runfolder_name}_SampleSheet.csv"
-        self.rtacompletefile_path = os.path.join(
-            self.runfolderpath, ToolboxConfig.FLAG_FILES["seq_complete"]
+        self.sequencer_type = get_sequencer_type(self.runfolder_name)
+        self.runfolderpath = get_runfolder_path(self.sequencer_type, self.runfolder_name)
+        self.aviti_runparameters_file = os.path.join(
+            self.runfolderpath, "RunParameters.json"
         )
-        self.samplesheet_path = os.path.join(
-            ToolboxConfig.RUNFOLDERS, "samplesheets", self.samplesheet_name
-        )
+        self.samplesheet_name = get_samplesheet_name(self.sequencer_type, self.runfolder_name, self.aviti_runparameters_file)
+        self.runcompletefile_path = get_runcompletefile_path(self.sequencer_type, self.runfolderpath)
+        self.samplesheet_path = get_samplesheet_path(self.sequencer_type, self.samplesheet_name)
         self.runfolder_samplesheet_path = os.path.join(
             self.runfolderpath, self.samplesheet_name
         )
@@ -466,18 +568,24 @@ class RunfolderObject(ToolboxConfig):
         self.sscheck_flagfile_path = os.path.join(
             self.runfolderpath, ToolboxConfig.FLAG_FILES["sscheck_flag"]
         )
-        self.bcl2fastqlog_file = os.path.join(
-            self.runfolderpath, ToolboxConfig.FLAG_FILES["bcl2fastqlog"]
-        )
-        self.fastq_dir_path = os.path.join(
-            self.runfolderpath, ToolboxConfig.FASTQ_DIRS["fastqs"]
-        )
+        self.demultiplexlog_file = get_demultiplexlog_file(self.sequencer_type, self.runfolderpath)
+        self.fastq_dir_path = get_fastq_dir_path(self.sequencer_type, self.runfolderpath)
         self.upload_flagfile = os.path.join(
             self.runfolderpath, ToolboxConfig.FLAG_FILES["upload_started"]
         )
-        self.bcl2fastqstats_file = os.path.join(
-            self.runfolderpath,
-            "Data/Intensities/BaseCalls/Stats/Stats.json",
+        bclconvert_stats = [
+            "Adapter_Cycle_Metrics.csv", "Adapter_Metrics.csv",
+            "Demultiplex_Stats.csv", "fastq_list.csv", "Index_Hopping_Counts.csv", 
+            "IndexMetricsOut.bin", "Quality_Metrics.csv", "Quality_Tile_Metrics.csv", 
+            "RunInfo.xml", "SampleSheet.csv", "Top_Unknown_Barcodes.csv"
+        ]
+        self.bclconvertstats_file = []
+        for stats in bclconvert_stats:
+            self.bclconvertstats_file.append(
+                os.path.join(
+                    self.runfolderpath,
+                    f"Data/Intensities/BaseCalls/Reports/{stats}", 
+            )
         )
         self.cluster_density_files = [
             os.path.join(
@@ -538,7 +646,7 @@ class RunfolderObject(ToolboxConfig):
             "sw": self.sw_runfolder_logfile,
             "demux": self.demultiplex_runfolder_logfile,
             "backup": self.upload_runfolder_logfile,
-            "bcl2fastq2": self.bcl2fastqlog_file,
+            "demultiplex_docker_log": self.demultiplexlog_file,
             "ss_validator": self.samplesheet_validator_logfile,
         }
         # Log files that sit outside the runfolder that require uploading
@@ -575,6 +683,8 @@ class RunfolderSamples(ToolboxConfig):
     An object with properties derived from the sample names in the samplesheet
 
     Attributes
+        sequencer_type (str):               Sequencer ID
+        samplesheet_name (str):             Samplesheet name string
         samplesheet_path (str):             Path to SampleSheet in SampleSheets dir
         runfolder_name (str):               Runfolder name string
         fastq_dir_path (str):               Runfolder fastq directory path (within runfolder)
@@ -636,6 +746,8 @@ class RunfolderSamples(ToolboxConfig):
             :param rf_obj (object):     RunfolderObject object (contains runfolder-specific attributes)
             :logger (logging.Logger):   Logger
         """
+        self.sequencer_type = rf_obj.sequencer_type
+        self.samplesheet_name = rf_obj.samplesheet_name
         self.samplesheet_path = rf_obj.samplesheet_path
         self.runfolder_name = rf_obj.runfolder_name
         self.fastq_dir_path = rf_obj.fastq_dir_path
@@ -644,7 +756,7 @@ class RunfolderSamples(ToolboxConfig):
         self.pipeline = self.get_pipeline()
         self.runtype_str = self.get_runtype()
         self.nexus_runfolder_suffix = self.get_nexus_runfolder_suffix()
-        self.nexus_paths = self.get_nexus_paths()
+        self.nexus_paths = self.get_nexus_paths(self.sequencer_type)
         self.unique_pannos = self.get_unique_pannos()
         self.samples_dict = self.get_samples_dict()
         self.check_for_missing_fastqs()
@@ -775,7 +887,7 @@ class RunfolderSamples(ToolboxConfig):
             self.logger.error(self.logger.log_msgs["wes_batch_nos_missing"])
             sys.exit(1)
 
-    def get_nexus_paths(self) -> dict:
+    def get_nexus_paths(self, sequencer_type: str) -> dict:
         """
         Build nexus paths, using NGS run numbers (and batch numbers in the case of WES).
         Builds the DNAnexus project name using the config-defined project prefix (denoting
@@ -788,11 +900,16 @@ class RunfolderSamples(ToolboxConfig):
         nexus_paths = {}
         if self.pipeline == "tso500":
             fastq_type = "tso_fastqs"
+        # Conditional added to reformat project name for AVITI runs (runfolder name leads to duplication) and
+        # direct to correct fastq location
+        elif sequencer_type == ToolboxConfig.AVITI_ID:
+            fastq_type = "aviti_fastqs"
+            amended_runfolder_name = self.samplesheet_name.replace("_SampleSheet.csv","")
         else:
-            fastq_type = "fastqs"
-
+            fastq_type = "illumina_fastqs"
+            amended_runfolder_name = self.runfolder_name
         nexus_paths["proj_name"] = (
-            f"{ToolboxConfig.DNANEXUS_PROJECT_PREFIX}{self.runfolder_name}_{self.nexus_runfolder_suffix}"
+            f"{ToolboxConfig.DNANEXUS_PROJECT_PREFIX}{amended_runfolder_name}_{self.nexus_runfolder_suffix}"
         )
         nexus_paths["fastqs_dir"] = os.path.join(
             f"/{self.runfolder_name}", ToolboxConfig.FASTQ_DIRS[fastq_type]
@@ -959,9 +1076,11 @@ class RunfolderSamples(ToolboxConfig):
             :return undetermined_fastqs_list (list): List of all undetermined fastqs in the run
         """
         undetermined_fastqs_list = []
-        r1 = os.path.join(self.fastq_dir_path, "Undetermined_S0_R1_001.fastq.gz")
-        r2 = os.path.join(self.fastq_dir_path, "Undetermined_S0_R2_001.fastq.gz")
-        for fastq in [r1, r2]:
+        illumina_r1 = os.path.join(self.fastq_dir_path, "Undetermined_S0_R1_001.fastq.gz")
+        illumina_r2 = os.path.join(self.fastq_dir_path, "Undetermined_S0_R2_001.fastq.gz")
+        aviti_r1 = os.path.join(self.fastq_dir_path, "Unassigned_R1.fastq.gz")
+        aviti_r2 = os.path.join(self.fastq_dir_path, "Unassigned_R2.fastq.gz")
+        for fastq in [illumina_r1, illumina_r2, aviti_r1, aviti_r2]:
             if os.path.exists(fastq):
                 undetermined_fastqs_list.append(fastq)
         return undetermined_fastqs_list
@@ -1177,7 +1296,7 @@ class SampleObject(ToolboxConfig):
             :return fastq_path (str):           Local fastq path
             :return nexus_fastq_path (str):     DNAnexus fastq path
         """
-        matches = [self.sample_name, f"_{read}_"]
+        matches = [self.sample_name, f"_{read}"]
         try:
             fastq_name = list(
                 fastq_path


### PR DESCRIPTION
Added all changes needed to process AVITI sequenced data that has been demultiplexed with Fastq folder and bases2fastq_output.log file created. Detailed description of all setoff_workflow changes are in markdown file attached.

Tested using validation runs from sequencer in _/media/data1/share/AV241501/testing_ by creating a 
symbolic link from sequencer output (_/media/data1/share/AV241501/_).

20250123_AV241501_NGS658FFV08Pool2AV in _/media/data1/share/AV241501/testing_ directory is a test dataset with empty fastq files. 

N.B. AVITI samplesheet location is still pointing to /media/data3/share/samplesheets/ currently - when this is updated the appropriate samplesheet will also need to be moved to new location for further testing.

[AV_SW_Updates.md](https://github.com/user-attachments/files/20575401/AV_SW_Updates.md)