### PR TITLE
debug_returncode_adx_upload

### DIFF
--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -415,6 +415,7 @@ class DemultiplexConfig(PanelConfig):
         f"docker run --rm --user %s:%s -v %s:/input_run {GATK_DOCKER} ./gatk CollectIlluminaLaneMetrics "
         "--RUN_DIRECTORY /input_run --OUTPUT_DIRECTORY /input_run --OUTPUT_PREFIX %s"
     )
+    ADX_LOG = f"{AD_LOGDIR}/archer_api_upload_logfiles/"
     ADX_CMD = (
         f"docker run "
         f"-v {RUNFOLDERS}/${{run_folder_name}}/Data/Intensities/BaseCalls:/data "

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -817,7 +817,7 @@ class ProcessRunfolder(SWConfig):
                 out,
                 err,
             )
-        elif os.path.exists(adx_log):
+        else:
             with open(adx_log, "r") as file:
                 content = file.read()
             if '"success":false' in content:
@@ -827,11 +827,12 @@ class ProcessRunfolder(SWConfig):
                     out,
                     err,
                 )
-        else:
-            self.loggers["sw"].info(
-                self.loggers["sw"].log_msgs["decision_run_success"],
-                self.rf_obj.runfolder_name,
-            )    
+            else:
+                self.loggers["sw"].info(
+                    self.loggers["sw"].log_msgs["decision_run_success"],
+                    self.rf_obj.runfolder_name,
+                )
+
     def run_dx_run_commands(self) -> None:
         """
         Execute the dx run bash script

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -809,13 +809,24 @@ class ProcessRunfolder(SWConfig):
         out, err, returncode = execute_subprocess_command(
             decision_support_run_cmd, self.loggers["sw"], "exit_on_fail"
         )
-        if returncode != 0:
+        adx_log = DemultiplexConfig.ADX_LOG + self.rf_obj.runfolder_name + "_archer_api_logfile.txt"
+        if returncode != 0 or not os.path.exists(adx_log):
             self.loggers["sw"].error(
                 self.loggers["sw"].log_msgs["decision_run_err"],
                 decision_support_run_cmd,
                 out,
                 err,
             )
+        elif os.path.exists(adx_log):
+            with open(adx_log, "r") as file:
+                content = file.read()
+            if '"success":false' in content:
+                self.loggers["sw"].error(
+                    self.loggers["sw"].log_msgs["decision_run_err"],
+                    decision_support_run_cmd,
+                    out,
+                    err,
+                )
         else:
             self.loggers["sw"].info(
                 self.loggers["sw"].log_msgs["decision_run_success"],


### PR DESCRIPTION
This is to debug the returncode for ADX upload.  In some cases, even uploading is not complete, returncode is still 0; therefore, success message string is still generated.  So, we need to check not only the returncode but also the archer log file to be able to generate the fail message correctly. I added a few lines of code to do the checks on archer log file so we don't wrongly generate the success message when it actually fails.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/581)
<!-- Reviewable:end -->
