### PR TITLE
Aviti Setoff Workflow changes

### DIFF
--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -105,7 +105,8 @@ ARCHER_DOCKER = (
 
 LANE_METRICS_SUFFIX = ".illumina_lane_metrics"
 DEMUX_NOT_REQUIRED_MSG = "%s run. Does not need demultiplexing locally"
-DEMULTIPLEX_SUCCESS = "Processing completed with 0 errors and 0 warnings."
+ILLUMINA_DEMULTIPLEX_SUCCESS = "Processing completed with 0 errors and 0 warnings."
+AVITI_DEMULTIPLEX_SUCCESS = "Output stored in /output"
 
 # -------------- DNANEXUS-SPECIFIC --------------------------------------------------------------
 
@@ -401,7 +402,6 @@ class DemultiplexConfig(PanelConfig):
         "demultiplex_not_required_msg": DEMUX_NOT_REQUIRED_MSG,
         "lane_metrics_suffix": LANE_METRICS_SUFFIX,
         "cd_success": "picard.illumina.CollectIlluminaLaneMetrics done",
-        "demultiplex_success": DEMULTIPLEX_SUCCESS,
         "checksums_assessed": "Checksums assessed by AS: %s",  # Written to file by AS
         "checksums_match": "Checksums match",  # Success message written to md5checksum file by integrity check scripts
         "checksums_do_not_match": "Checksums do not match",  # Failure message written to md5sum file by integrity check scripts
@@ -479,6 +479,8 @@ class SWConfig(PanelConfig):
     SDK_SOURCE = SDK_SOURCE
     UPLOAD_ARGS = UPLOAD_ARGS
     RUNFOLDERS = RUNFOLDERS
+    AVITI_RUNFOLDER = AVITI_RUNFOLDER
+    AVITI_ID = AVITI_ID
     PROD_ORGANISATION = "org-viapath_prod"  # Prod org for billing
     if BRANCH == "main":  # Prod branch
 
@@ -506,7 +508,8 @@ class SWConfig(PanelConfig):
     STRINGS = {
         "demultiplex_not_required_msg": DEMUX_NOT_REQUIRED_MSG,
         "lane_metrics_suffix": LANE_METRICS_SUFFIX,
-        "demultiplex_success": DEMULTIPLEX_SUCCESS,
+        "illumina_demultiplex_success": ILLUMINA_DEMULTIPLEX_SUCCESS,
+        "aviti_demultiplex_success": AVITI_DEMULTIPLEX_SUCCESS,
     }
     PIPE_FH_GATK_TIMEOUT_ARGS = (  # This is specified for the GATK app in the Custom Panels pipeline for only FH samples
         # Set 6 hour timeout policy for gatk app and jobtimeoutexceeded
@@ -710,6 +713,7 @@ class URConfig:
     CREDENTIALS = CREDENTIALS
     DX_CMDS = DX_CMDS
     TIMESTAMP = TIMESTAMP
+    AVITI_ID = AVITI_ID
     STRINGS = {
         "upload_started": "Upload started",  # Statement to write to DNAnexus upload started file
     }

--- a/config/log_msgs_config.py
+++ b/config/log_msgs_config.py
@@ -124,7 +124,7 @@ LOG_MSGS = {
         "demux_complete": "Run has been previously successfully processed by the demultiplexing script",
         "success_string_absent": "Run has previously been demultiplexed but no success string is present",
         "not_yet_demultiplexed": "Demultiplexing has not been performed",
-        "bclconvertlog_empty": "Bclconvert log file exists but is empty",
+        "demultiplexlog_empty": "Demultiplex log file exists but is empty",
         "nonexistent_files": "Not all files exist: %s",
         "view_users": "Users identifed that require VIEW project permissions: %s",
         "admin_users": "Users identifed that require ADMINISTER project permissions: %s",

--- a/setoff_workflows/README.md
+++ b/setoff_workflows/README.md
@@ -1,6 +1,6 @@
 # Set Off Workflows
 
-The setoff_workflows module handles the DNAnexus workflow / app execution for demultiplexed NGS runs. The module contains
+The setoff_workflows module handles the DNAnexus workflow / app execution for demultiplexed NGS runs sequenced via Illumina and AVITI. The module contains
 multiple scripts:
 
 | Script | Class | Functionality|
@@ -19,7 +19,7 @@ The module uses various functions and classes from the [Toolbox module](../toolb
 ## Protocol
 
 1. Identify runfolders in the runfolders directory which have not been processed:
-    - Runfolder contains bclconvert log file with success string
+    - Runfolder contains demultiplex log file with success string (`bclconvert_output.log`/`bases2fastq_output.log`)
     - Runfolder does not contain upload started flag file (has not yet been uploaded to DNAnexus)
 2. Collect names and metadata for all samples in the runfolder, using the RunfolderSamples() class from the [Toolbox module](../toolbox/toolbox.py).
 3. Write and run the DNAnexus project creation script

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -116,21 +116,32 @@ class SequencingRuns(SWConfig):
 
     def set_runfolders(self) -> list:
         """
-        Update self.runs_to_process list with NGS runfolders in the runfolders directory
-        that match the runfolder pattern, and require processing by the script
+        Update self.runs_to_process list with NGS runfolders in Illumina and AVITI
+        runfolders directory that match the runfolder pattern, and require processing 
+        by the script
             :return (list):     List of runfolder objects that require processing
         """
         runs_to_process = []
-        for folder in os.listdir(SWConfig.RUNFOLDERS):
-            if os.path.isdir(os.path.join(SWConfig.RUNFOLDERS, folder)) and re.compile(
-                SWConfig.RUNFOLDER_PATTERN
-            ).match(folder):
-                script_logger.info(
-                    script_logger.log_msgs["runfolder_identified"], folder
-                )
-                rf_obj = RunfolderObject(folder, SWConfig.TIMESTAMP)
-                if self.requires_processing(rf_obj):
-                    runs_to_process.append(rf_obj)
+        # Combine Illumina and AVITI runs in respecitve directories
+        # into one list
+        illumina_runfolders = os.listdir(SWConfig.RUNFOLDERS)
+        aviti_runfolders = os.listdir(SWConfig.AVITI_RUNFOLDER)
+        sequenced_folders = illumina_runfolders + aviti_runfolders
+        # Iterate through list and check directory follows runfolder pattern and also exists in 
+        # either the Illumina or AVITI directory. Specific Runfolder path is confirmed when 
+        # RunFolderObject is created in Toolbox.py
+        for folder in sequenced_folders:
+            if re.compile(SWConfig.RUNFOLDER_PATTERN).match(folder):
+                if os.path.isdir(
+                    os.path.join(SWConfig.RUNFOLDERS, folder)
+                    ) or os.path.isdir(
+                        os.path.join(SWConfig.AVITI_RUNFOLDER, folder)):
+                    script_logger.info(
+                        script_logger.log_msgs["runfolder_identified"], folder
+                    )
+                    rf_obj = RunfolderObject(folder, SWConfig.TIMESTAMP)
+                    if self.requires_processing(rf_obj):
+                        runs_to_process.append(rf_obj)
         return runs_to_process
 
     def requires_processing(self, rf_obj: object) -> Optional[bool]:
@@ -161,11 +172,12 @@ class SequencingRuns(SWConfig):
             :param rf_obj (obj):        RunfolderObject object (contains runfolder-specific attributes)
             :return (Optional[bool]):   Return True if runfolder already demultiplexed, else None
         """
-        if os.path.isfile(rf_obj.bclconvertlog_file):
-            logfile_list = read_lines(rf_obj.bclconvertlog_file)
+        if os.path.isfile(rf_obj.demultiplexlog_file):
+            logfile_list = read_lines(rf_obj.demultiplexlog_file)
             completed_strs = [
                 SWConfig.STRINGS["demultiplex_not_required_msg"].partition(" ")[-1],
-                SWConfig.STRINGS["demultiplex_success"],
+                SWConfig.STRINGS["illumina_demultiplex_success"],
+                SWConfig.STRINGS["aviti_demultiplex_success"],
             ]
             if logfile_list:
                 if any(
@@ -177,7 +189,7 @@ class SequencingRuns(SWConfig):
                 else:
                     script_logger.info(script_logger.log_msgs["success_string_absent"])
             else:
-                script_logger.info(script_logger.log_msgs["bclconvertlog_empty"])
+                script_logger.info(script_logger.log_msgs["demultiplexlog_empty"])
         else:
             script_logger.info(script_logger.log_msgs["not_yet_demultiplexed"])
 
@@ -491,7 +503,9 @@ class ProcessRunfolder(SWConfig):
             )
         if self.rf_samples_obj.pipeline != "tso500":
             # tso500 run is not demultiplexed locally so there are no fastqs
-            # All other runfolders have fastqs in the BaseCalls directory
+            # All other runfolders have fastqs in the BaseCalls directory.
+            # This section covers uploading AVITI fastqs as this is only thing
+            # Needed for DNANexus processing
             upload_cmds["fastqs"] = SWConfig.DX_CMDS["file_upload_cmd"] % (
                 self.rf_obj.dnanexus_auth,
                 self.nexus_identifiers["proj_id"],
@@ -590,12 +604,8 @@ class ProcessRunfolder(SWConfig):
             :return pre_pipeline_upload_dict (dict):    Dict of files to upload prior to
                                                         pipeline setoff, and commands
         """
-        pre_pipeline_upload_dict = {
-            "cluster density": {
-                "cmd": self.upload_cmds["cd"],
-                "files_list": self.rf_obj.cluster_density_files,
-            },
-        }
+        pre_pipeline_upload_dict = {}
+
         if self.rf_samples_obj.pipeline == "tso500":  # Add SampleSheet entry
             pre_pipeline_upload_dict["runfolder_samplesheet"] = {
                 "cmd": self.upload_cmds["runfolder_samplesheet"],
@@ -616,9 +626,14 @@ class ProcessRunfolder(SWConfig):
                     *self.rf_samples_obj.undetermined_fastqs_list,
                 ],
             }
-            pre_pipeline_upload_dict["bclconvert_qc"] = {
+            if self.rf_obj.sequencer_type != SWConfig.AVITI_ID:
+                pre_pipeline_upload_dict["bclconvert_qc"] = {
                 "cmd": self.upload_cmds["bclconvert_qc"],
                 "files_list": self.rf_obj.bclconvertstats_file,
+            }
+                pre_pipeline_upload_dict["cluster_density"] = {
+                "cmd": self.upload_cmds["cd"],
+                "files_list": self.rf_obj.cluster_density_files,
             }
             if self.rf_samples_obj.pipeline == "oncodeep":  # Add MasterFile entry
                 pre_pipeline_upload_dict["masterfile"] = {
@@ -767,19 +782,21 @@ class ProcessRunfolder(SWConfig):
 
     def upload_rest_of_runfolder(self) -> None:
         """
-        Backs up the rest of the runfolder. Specifies which files to ignore (excludes BCL files for all
-        runs except tso500 runs for which they are needed for demultiplexing on DNAnexus). Calls
-        upload_runfolder.upload_rest_of_runfolder(ignore), passing a run-dependent ignore string, and
-        the this handles the runfolder upload. upload_runfolder writes log messages to the upload
+        Backs up the rest of the runfolder. Specifies which files to ignore (excludes BCL files for all Illumina
+        runs except tso500 runs for which they are needed for demultiplexing on DNAnexus & all primary sequence output data
+        for AVITI Runs). Calls upload_runfolder.upload_rest_of_runfolder(ignore), passing a run-dependent ignore string, and
+        then this handles the runfolder upload. upload_runfolder writes log messages to the upload
         runfolder log file. If unsuccessful, exit script
             :return None:
         """
-        # Build upload_runfolder.py commands, ignoring some files
-        if self.rf_samples_obj.pipeline in ["tso500", "dev"]:
+        # Build upload_runfolder.py commands, ignoring BCL files for Illumina runs and Bases zip files, 
+        # Alignement, Filter and Location files for AVITI runs 
+        if self.rf_samples_obj.pipeline in ["tso500"]:
             ignore = ""  # Upload BCL files for tso500 and dev runs
+        elif self.rf_samples_obj.sequencer_type == SWConfig.AVITI_ID:
+            ignore = "/BaseCalls,/Alignment,/Filter,/Location"
         else:
             ignore = "/L00"
-
         try:
             self.loggers["sw"].info(
                 self.loggers["sw"].log_msgs["uploading_rf"],

--- a/toolbox/toolbox.py
+++ b/toolbox/toolbox.py
@@ -1097,9 +1097,11 @@ class RunfolderSamples(ToolboxConfig):
             :return undetermined_fastqs_list (list): List of all undetermined fastqs in the run
         """
         undetermined_fastqs_list = []
-        r1 = os.path.join(self.fastq_dir_path, "Undetermined_S0_R1_001.fastq.gz")
-        r2 = os.path.join(self.fastq_dir_path, "Undetermined_S0_R2_001.fastq.gz")
-        for fastq in [r1, r2]:
+        illumina_r1 = os.path.join(self.fastq_dir_path, "Undetermined_S0_R1_001.fastq.gz")
+        illumina_r2 = os.path.join(self.fastq_dir_path, "Undetermined_S0_R2_001.fastq.gz")
+        aviti_r1 = os.path.join(self.fastq_dir_path, "Unassigned_R1.fastq.gz")
+        aviti_r2 = os.path.join(self.fastq_dir_path, "Unassigned_R2.fastq.gz")
+        for fastq in [illumina_r1, illumina_r2, aviti_r1, aviti_r2]:
             if os.path.exists(fastq):
                 undetermined_fastqs_list.append(fastq)
         return undetermined_fastqs_list

--- a/upload_runfolder/upload_runfolder.py
+++ b/upload_runfolder/upload_runfolder.py
@@ -18,6 +18,7 @@ from toolbox.toolbox import (
     test_upload_software,
     get_credential,
     write_lines,
+    get_sequencer_type,
 )
 
 
@@ -85,6 +86,7 @@ class UploadRunfolder(URConfig):
             :param logger (logging.Logger): Logger
             :param runfolder_name (str):    Runfolder name
             :param runfolderpath (str):     Path of runfolder on workstation
+            :param sequencer_type (str):    Sequencer ID
             :param upload_flagfile (str):   Path to flag file that denotes runfolder upload has started
             :param nexus_identifiers        Dictionary of proj_name and proj_id, or False
             (dict | False):
@@ -92,6 +94,7 @@ class UploadRunfolder(URConfig):
         self.logger = logger
         self.runfolder_name = runfolder_name
         self.runfolderpath = runfolderpath
+        self.sequencer_type = get_sequencer_type(runfolder_name)
         self.dnanexus_auth = get_credential(URConfig.CREDENTIALS["dnanexus_authtoken"])
         self.upload_flagfile = upload_flagfile
         if nexus_identifiers:
@@ -341,11 +344,22 @@ class UploadRunfolder(URConfig):
             ).group(1)
         # Prepend nexus folder path to cleaned path. the nexus folder path is
         # the project name without the first four characters (002_)
-        nexus_project_subdirectory = os.path.join(
+        # Conditional added to alter subdirectory path for AVITI as folder name and run name
+        # are different - keeps same folder structure within project as on workstation
+        if self.sequencer_type == URConfig.AVITI_ID:
+            split_subfolder = self.nexus_identifiers["proj_name"].split("_")
+            amended_subfolder = "20" + ("_".join([split_subfolder[1],split_subfolder[2],split_subfolder[4]]))
+            nexus_project_subdirectory = os.path.join(
             "/",
-            "_".join(self.nexus_identifiers["proj_name"].split("_")[1:5]),
+            amended_subfolder,
             clean_runfolder_path,
         )
+        else:
+            nexus_project_subdirectory = os.path.join(
+                "/",
+                "_".join(self.nexus_identifiers["proj_name"].split("_")[1:5]),
+                clean_runfolder_path,
+            )
         self.logger.info(
             self.logger.log_msgs["nexus_project_subdirectory"],
             nexus_project_subdirectory,


### PR DESCRIPTION
Added all changes needed to process AVITI sequenced data that has been demultiplexed with Fastq folder and bases2fastq_output.log file created. Detailed description of all setoff_workflow changes are in markdown file attached.

20250123_AV241501_NGS658FFV08Pool2AV in /media/data1/share/AV241501/testing directory is a test dataset with empty fastq files.
[AV_SW_Updates.md](https://github.com/user-attachments/files/20672848/AV_SW_Updates.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/585)
<!-- Reviewable:end -->
