### PR TITLE
Ed calling variable instances

### DIFF
--- a/setoff_workflows/build_dx_commands.py
+++ b/setoff_workflows/build_dx_commands.py
@@ -270,17 +270,25 @@ class BuildRunfolderDxCommands(SWConfig):
             ]
         )
 
-    def create_ed_cnvcalling_cmd(self, panno: str) -> str:
+    def create_ed_cnvcalling_cmd(self, panno: str, sample_count: int = 1) -> str:
         """
         Build dx run command for exomedepth cnv calling app
-            :param panno (str):     Pannumber to filter CNV calls
-            :return (str):          Dx run command for ED cnv calling app
+            :param panno (str):         Pannumber to filter CNV calls
+            :param sample_count (int):  Number of samples sharing this pan number
+            :return (str):              Dx run command for ED cnv calling app
         """
         self.logger.info(
             self.logger.log_msgs["building_cmd"],
             "ED_cnvcalling",
             panno,
         )
+        
+        # Set instance type based on sample count
+        if sample_count >= 8:
+            cnv_instance = "mem1_ssd1_v2_x8" # Increase instance size to accomodate larger number of samples
+        else:
+            cnv_instance = "mem1_ssd1_v2_x4"  # Default DNAnexus instance
+        
         return " ".join(
             [
                 f'{SWConfig.DX_CMDS["ed_cnvcalling"]}ED_CNVcalling-{panno}',
@@ -295,9 +303,8 @@ class BuildRunfolderDxCommands(SWConfig):
                 f'{SWConfig.BEDFILE_FOLDER}{SWConfig.PANEL_DICT[panno]["ed_cnvcalling_bedfile"]}_CNV.bed',
                 SWConfig.APP_INPUTS["ed_cnvcalling"]["proj"],
                 f'{SWConfig.APP_INPUTS["ed_cnvcalling"]["pannos"]}{panno}',
-                SWConfig.UPLOAD_ARGS[
-                    "depends_pipeline"
-                ],  # Use list of gatk related jobs to delay start
+                f'--instance-type {cnv_instance}',  # Add instance type specification
+                SWConfig.UPLOAD_ARGS["depends_pipeline"],
                 SWConfig.UPLOAD_ARGS["dest"],
                 SWConfig.UPLOAD_ARGS["token"],
             ]

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -1368,9 +1368,12 @@ class CustomPanelsPipelines:
                             ]
                             and SWConfig.PANEL_DICT[panno]["ed_cnvcalling_bedfile"]
                         ):
+                            # Count how many samples share this pan number
+                            sample_count = core_panel_pannos.count(panno)
+                            
                             self.workflow_cmds.extend(
                                 [
-                                    self.rf_cmds_obj.create_ed_cnvcalling_cmd(panno),
+                                    self.rf_cmds_obj.create_ed_cnvcalling_cmd(panno, sample_count),
                                     SWConfig.UPLOAD_ARGS["depends_list_cnvcalling"],
                                 ]
                             )


### PR DESCRIPTION
Minor adjustment to resolve intermittent DNAnexus `Low disk space` errors occurring during individual CNV calling tasks in the CP2 pipeline. This occurs where the accumulative size of FASTQs required to perform a task exceeds 100GB.

Change adds an additional `--instance_type` arg to generated CNV calling dx commands based on the overall number of samples sharing a Pan number within the run. Where this exceeds 7, `mem1_ssd1_v2_x8` (200GB scratch space) is selected over the default `mem1_ssd1_v2_x4` (100GB scratch space).

- Calculate and pass the overall `sample_count` for samples sharing a Pan number from `CustomPanelsPipelines` class in `setoff_workflows.py`
- Conditional check in `create_ed_cnvcalling_cmd` function within `build_dx_commands.py` to set `cnv_instance` var based on `sample_count`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/592)
<!-- Reviewable:end -->
