### PR TITLE
Adx upload py

### DIFF
--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -100,7 +100,7 @@ GATK_DOCKER = (
     "broadinstitute/gatk:4.1.8.1"  # TODO this image should have a hash added in future
 )
 ARCHER_DOCKER = (
-    "seglh/archer_api_upload:v1.0.0"
+    "seglh/archer_api_upload_py:6ff3ff0"
 )
 
 LANE_METRICS_SUFFIX = ".illumina_lane_metrics"
@@ -432,11 +432,13 @@ class DemultiplexConfig(PanelConfig):
     ADX_LOG = f"{AD_LOGDIR}/archer_api_upload_logfiles/"
     ADX_CMD = (
         f"docker run "
-        f"-v {RUNFOLDERS}/${{run_folder_name}}/Data/Intensities/BaseCalls:/data "
+        f"-v {RUNFOLDERS}/${{run_folder_name}}/Data/Intensities/BaseCalls:/${{run_folder_name}} "
         f"-v {DOCUMENT_ROOT}:/auth_file "
-        f"{ARCHER_DOCKER} /data "
-        f"auth_file/{CREDENTIALS['adx_authtoken']} "
-        f"${{job_name}} 2 | tee -a {AD_LOGDIR}/archer_api_upload_logfiles/${{run_folder_name}}_archer_api_logfile.txt"
+        f"-v {ADX_LOG}:/log_dir "
+        f"{ARCHER_DOCKER} --runfolder /${{run_folder_name}} "
+        f"--cred_file /auth_file/{CREDENTIALS['adx_authtoken']} "
+        f"--log_dir /log_dir "
+        f"--job_name ${{job_name}}"
     )
     MSK_CMD = (
         f"python3 /usr/local/src/mokaguys/sophia_cli/sophia.py "

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -846,7 +846,10 @@ class ProcessRunfolder(SWConfig):
         else:
             with open(adx_log, "r") as file:
                 content = file.read()
-            if '"success":false' in content:
+            error_words = ["'success': False", "failed to upload",
+                           "data not found in respJSON",
+                           "data key not found"]
+            if any(error_word in content for error_word in error_words):
                 self.loggers["sw"].error(
                     self.loggers["sw"].log_msgs["decision_run_err"],
                     decision_support_run_cmd,


### PR DESCRIPTION
This is to replace the docker image for archer api upload to use python instead of shell. The upload for each fastq will be re-tried for max 5 times if fails. 
The updated AS was tested with a test run and confirmed it passed. Never needed to retry more than 3 times so 5 retries should be enough. Number of retry can be checked in the log file so network connection status can be tracked. 
Archer api key for new docker has also been updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/595)
<!-- Reviewable:end -->
