### PR TITLE
update ws branch name for prod

### DIFF
--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -36,7 +36,7 @@ MAIL_SETTINGS = {
     "alerts_email": "moka.alerts@gstt.nhs.uk",
 }
 
-if BRANCH == "main" and "pytest" not in sys.modules:  # Prod branch
+if BRANCH in ("main", "ws_main_from_v45.4.0") and "pytest" not in sys.modules:  # Prod branch
     TESTING = False  # Set testing mode
     SCRIPT_MODE = "PROD_MODE"
     JOB_NAME_STR = "--name "


### PR DESCRIPTION
This is to add AS branch name for workstation prod mode. Currently, only "main" branch is used as prod mode. But with new archer docker image update, a separate ws_main branch was created to separate from Turing main branch. This ws_main branch is named as "ws_main_from_v45.4.0". So, ws AS needs to use either main or ws_main_from_v45.4.0 for prod. 