### PR TITLE
update ws main brach name for prod

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - develop
+      - ws_main_from_v45.4.1
+      - ws_dev_from_v45.4.1
       - 'feature/**'
       - 'hotfix/**'
 jobs:

--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -36,7 +36,7 @@ MAIL_SETTINGS = {
     "alerts_email": "moka.alerts@gstt.nhs.uk",
 }
 
-if BRANCH == "main" and "pytest" not in sys.modules:  # Prod branch
+if BRANCH in ("main", "ws_main_from_v45.4.1") and "pytest" not in sys.modules:  # Prod branch
     TESTING = False  # Set testing mode
     SCRIPT_MODE = "PROD_MODE"
     JOB_NAME_STR = "--name "
@@ -485,7 +485,7 @@ class SWConfig(PanelConfig):
     AVITI_RUNFOLDER = AVITI_RUNFOLDER
     AVITI_ID = AVITI_ID
     PROD_ORGANISATION = "org-viapath_prod"  # Prod org for billing
-    if BRANCH == "main":  # Prod branch
+    if BRANCH in ("main", "ws_main_from_v45.4.1"):  # Prod branch
 
         BSPS_ID = "BSPS_MD"
         DNANEXUS_USERS = {  # User access level
@@ -650,7 +650,7 @@ class ToolboxConfig(PanelConfig):
     Toolbox configuration
     """
 
-    if BRANCH == "main":
+    if BRANCH in ("main", "ws_main_from_v45.4.1"):
         DNANEXUS_PROJECT_PREFIX = "002_"  # Denotes production status of run
     else:
         DNANEXUS_PROJECT_PREFIX = "003_"  # Denotes development status of run


### PR DESCRIPTION
This is to revert the workstation prod from `ws_main_from_45.4.0` to its original correct version `45.4.1`. 
- a dev branch named `ws_dev_from_v45.4.1` was created based on `45.4.1`. 
- a feature branch named `to_revert_back_to_45.4.1` was created based on `ws_dev_from_v45.4.1`
- On the feature branch, changes were done to include prod branch name in config and yml file . 
- after these changes have been code reviewed and merged into `ws_dev_from_v45.4.1`, the dev branch is going to merged into `ws_main_from_v45.4.1` that also bases on version `45.4.1`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/601)
<!-- Reviewable:end -->
