### PR TITLE
Patch to address Python sendmail changes in response to CWE-1286

### DIFF
--- a/ad_email/ad_email.py
+++ b/ad_email/ad_email.py
@@ -107,11 +107,9 @@ class AdEmail(AdEmailConfig):
         self.msg = MIMEMultipart()  # Create email message object and specify settings
         self.msg["X-Priority"] = str(email_priority)  # Set email priority. 1 is highest
         try:
-            recipients = ", ".join(recipients)
-
             self.msg["Subject"] = email_subject
             self.msg["From"] = self.sender
-            self.msg["To"] = recipients
+            self.msg["To"] = ", ".join(recipients)
             self.msg.attach(
                 MIMEText(email_message, "html", "utf-8")
             )  # Add msg to e-mail body


### PR DESCRIPTION
AS is failing to send emails where there are multiple recipients. 

`ERROR - Email not sent. Exception: {'gst-tr.mokaguys@nhs.net, synnovis.seglh-ods@nhs.net': (501, b'Invalid RCPT TO address provided')}`

This is a minor patch to pass recipients as a list in the sendmail function call as opposed to a single string.

The option to pass multiple recipient mail address as a single string was removed as part of addressing a security vulnerability (https://python-security.readthedocs.io/vuln/email-parseaddr-realname.html) in Python 3. This change aligns with best practices and is cross compatible with older revisions of Python 3.10, so may also be applicable to branches running on the NGS workstation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/607)
<!-- Reviewable:end -->
