### PR TITLE
Append cmds to workflow_cmds list to generate dx_run_commands file

### DIFF
--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -1073,6 +1073,8 @@ class MskPipeline:
         docker_api_cmd = [MSK_runfolder, MSK_jobID, docker]
         for api_cmd in docker_api_cmd:
             self.decision_support_upload_cmds.append(api_cmd)
+        # Record MSK commands in workflow list so a dx_run_commands script is generated
+        self.workflow_cmds.extend(self.decision_support_upload_cmds)
 
 class SnpPipeline:  # TODO eventually remove this and associated pipeline-specific functions
     """


### PR DESCRIPTION
Small change to add commands to workflow_cmds list in order to force dx_run_commands.sh file generation. This is intended to mute errors relating to missing files during automated processing of MSK runs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/615)
<!-- Reviewable:end -->
