### PR TITLE
Fastq validation failure flagging

### DIFF
--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -410,6 +410,7 @@ class DemultiplexConfig(PanelConfig):
         "samplesheet_success": "Samplesheet check successful with no errors identified: %s",
         "samplesheet_fail": "Processing halted. SampleSheet contains SampleSheet errors: %s ",
         "upload_flag_umis": "Runfolder contains UMIs. Runfolder will not be uploaded and requires manual upload: %s",
+        "fastq_validation_fail_flag": "Fastq validation failed on %s. Remove this file after resolving the issue to re-trigger demultiplexing.",
     }
     TESTING = TESTING
     BCLCONVERT_CMD = (
@@ -686,6 +687,7 @@ class ToolboxConfig(PanelConfig):
         "sscheck_flag": "sscheck_flagfile.txt",  # Denotes SampleSheet has been checked
         "illumina_seq_complete": "RTAComplete.txt",  # Illumina Sequencing complete file
         "aviti_seq_complete": "RunUploaded.json", # AVITI Sequencing complete file
+        "fastq_validation_fail": "fastq_validation_failed.txt",  # Prevent repeated demultiplex attempts after validation failure
     }
     TEST_PROGRAMS_DICT = {
         "dx_toolkit": {

--- a/config/log_msgs_config.py
+++ b/config/log_msgs_config.py
@@ -110,6 +110,10 @@ LOG_MSGS = {
         "file_copy_success": "File successfully copied from %s to %s",
         "file_copy_fail": "Could not copy file - file does not exist: %s",
         "re_demultiplex": "Invalid fastqs were identified. Demultiplex log has been removed to trigger re-demultiplex",
+        "fastq_validation_flagfile_created": "Created fastq validation failure flagfile: %s",
+        "fastq_validation_flagfile_present": (
+            "Fastq validation previously failed for this run. Remove %s after fixing the issue to allow reprocessing"
+        ),
     },
     "sw": {
         "runfolder_identified": "Identified runfolder: %s",

--- a/demultiplex/demultiplex.py
+++ b/demultiplex/demultiplex.py
@@ -299,7 +299,11 @@ class DemultiplexRunfolder(DemultiplexConfig):
         returns True as demultiplexing is required
             :return None:
         """
-        if self.upload_flagfile_absent() and self.demultiplex_docker_log_absent():
+        if (
+            self.upload_flagfile_absent()
+            and self.demultiplex_docker_log_absent()
+            and self.fastq_validation_fail_flag_absent()
+        ):
             if not self.previous_samplesheet_check_fail():
                 self.demux_rf_logger.info(
                     self.demux_rf_logger.log_msgs["ad_version"],
@@ -350,6 +354,19 @@ class DemultiplexRunfolder(DemultiplexConfig):
                 script_logger.log_msgs["demux_not_complete"],
                 self.rf_obj.demultiplexlog_file,
             )
+            return True
+
+    def fastq_validation_fail_flag_absent(self) -> Optional[bool]:
+        """
+        Check if a previous fastq validation failure flag file is present
+            :return (Optional[bool]): Return True if no previous flag exists
+        """
+        if os.path.isfile(self.rf_obj.fastq_validation_fail_flagfile):
+            script_logger.info(
+                script_logger.log_msgs["fastq_validation_flagfile_present"],
+                self.rf_obj.fastq_validation_fail_flagfile,
+            )
+        else:
             return True
 
     def previous_samplesheet_check_fail(self) -> Optional[bool]:
@@ -854,6 +871,16 @@ class DemultiplexRunfolder(DemultiplexConfig):
                                 dest_file.write(line)
                 return True
             else:
+                write_lines(
+                    self.rf_obj.fastq_validation_fail_flagfile,
+                    "w",
+                    DemultiplexConfig.STRINGS["fastq_validation_fail_flag"]
+                    % datetime.datetime.now(),
+                )
+                self.demux_rf_logger.info(
+                    self.demux_rf_logger.log_msgs["fastq_validation_flagfile_created"],
+                    self.rf_obj.fastq_validation_fail_flagfile,
+                )
                 os.remove(
                     self.rf_obj.demultiplexlog_file
                 )  # Demultiplexing log file removed to trigger re-demultiplex

--- a/toolbox/toolbox.py
+++ b/toolbox/toolbox.py
@@ -588,6 +588,9 @@ class RunfolderObject(ToolboxConfig):
         self.sscheck_flagfile_path = os.path.join(
             self.runfolderpath, ToolboxConfig.FLAG_FILES["sscheck_flag"]
         )
+        self.fastq_validation_fail_flagfile = os.path.join(
+            self.runfolderpath, ToolboxConfig.FLAG_FILES["fastq_validation_fail"]
+        )
         self.demultiplexlog_file = get_demultiplexlog_file(self.sequencer_type, self.runfolderpath)
         self.bclconvert_log_output_dir = os.path.join(
             self.runfolderpath, "Bcl_convert_logs"


### PR DESCRIPTION
Small update to generate a flag file in cases where FASTQ validation fails after demultiplex. This is necessary to prevent infinite retry loop.

- Added a new fastq_validation_failed.txt flag definition in ad_config.py
- Exposed its path on RunfolderObject in toolbox.py so each run can record a persistent validation failure.
- Introduced log messages for flag creation/presence in log_msgs_config.py.
- Gated demuxing on the flag absence in demultiplex.py. When validate_fastqs fails, AS will now write the flag, log why (and trigger Slack alert), and still delete the demux log (as per existing design) to unblock future processing once the issue is fixed (stdout demux log will still persist in logfiles for debugging).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/621)
<!-- Reviewable:end -->
