### PR TITLE
Small fix to include gatk_pipe to for excluded samples logic

### DIFF
--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -1423,7 +1423,7 @@ class CustomPanelsPipelines:
             :param sample_name (str):   Sample name string
             :return (bool):             True if sample has failed fastqs and pipeline is seglh_pipe
         """
-        if self.rf_samples_obj.pipeline != "seglh_pipe":
+        if self.rf_samples_obj.pipeline not in ["seglh_pipe", "gatk_pipe"]:
             return False
         if not hasattr(self.rf_obj, "failed_fastqs") or not self.rf_obj.failed_fastqs:
             return False


### PR DESCRIPTION
Adding gatk_pipe to the list of runs where failed samples are excluded from bash run commands generated in setoff_workflows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/627)
<!-- Reviewable:end -->
