### PR TITLE
Switched RTAComplete with CopyComplete to ensure processing waits

### DIFF
--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -692,7 +692,7 @@ class ToolboxConfig(PanelConfig):
         "filecheck": "filecheck.txt",  # File holding integrity check results
         "initial_sscheck_flag": "initial_sscheck_flagfile.txt",  # Denotes initial SampleSheet has been checked
         "sscheck_flag": "sscheck_flagfile.txt",  # Denotes SampleSheet has been checked
-        "illumina_seq_complete": "RTAComplete.txt",  # Illumina Sequencing complete file
+        "illumina_seq_complete": "CopyComplete.txt",  # Illumina Sequencing complete file after network copy
         "aviti_seq_complete": "RunUploaded.json", # AVITI Sequencing complete file
     }
     TEST_PROGRAMS_DICT = {


### PR DESCRIPTION
The current logic is using the RTAComplete.txt file to assess when a runfolder is ready to start integrity checking/demultiplexing for Illumina runs. This is problematic as the file is typically present before the data has completely copied to the workstation.

Switched to CopyComplete to ensure run is complete and present.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/628)
<!-- Reviewable:end -->
