### PR TITLE
Update to conftest.py to amend pytests for new CopyComplete.txt checks

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -106,24 +106,33 @@ def run_before_and_after_session():
     for destination in to_copy_interop_to:
         shutil.copytree(os.path.join(test_data_dir_unzipped, "InterOp"), destination)
 
-    test_data_unzipped = os.path.join(
+    test_data_unzipped_path = os.path.join(
         test_data_dir_unzipped, "demultiplex_test_files", "test_runfolders"
     )
 
     directories = [
-        os.path.join(test_data_unzipped, d)
-        for d in os.listdir(test_data_unzipped)
-        if os.path.isdir(os.path.join(test_data_unzipped, d))
+        os.path.join(test_data_unzipped_path, d)
+        for d in os.listdir(test_data_unzipped_path)
+        if os.path.isdir(os.path.join(test_data_unzipped_path, d))
     ]
     dummy_fastq = os.path.join(test_data_dir, "dummy_fastq.gz")
+
+    # Folders that should NOT have a completion file so fail tests can pass
+    incomplete_folders = ["00000TEST1", "00000TEST2"]
 
     for directory in directories:
         if re.match(".*999999_.*", directory):
             fastqs_dir = os.path.join(
-                test_data_unzipped, directory, "Data", "Intensities", "BaseCalls/"
+                directory, "Data", "Intensities", "BaseCalls/"
             )
             os.makedirs(fastqs_dir, exist_ok=True)
             copy(dummy_fastq, fastqs_dir)
+
+            # Add CopyComplete.txt if it's not one of the designated 'fail' folders
+            if not any(x in directory for x in incomplete_folders):
+                copy_complete_path = os.path.join(directory, "CopyComplete.txt")
+                open(copy_complete_path, "w").close()
+
     yield  # Where the testing happens
     for to_remove in [test_data_dir_unzipped, test_data_temp]:
         if os.path.isdir(to_remove):


### PR DESCRIPTION
Update to conftest.py testing suite to add CopyComplete.txt file to 'pass' designated test runfolders.

All tests now pass as expected:                                                                                                                                                                                                                                                                   

```
demultiplex/test_demultiplex.py::TestGetRunfolders::test_setoff_processing_nottoproc PASSED                                                                                                                                                                                         [  5%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_demultiplexlog_absent_false PASSED                                                                                                                                                                                  [ 10%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_demultiplexlog_absent_true PASSED                                                                                                                                                                                   [ 15%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_setoff_workflow_success PASSED                                                                                                                                                                                      [ 20%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_setoff_workflow_fail PASSED                                                                                                                                                                                         [ 25%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_demultiplexing_required_true PASSED                                                                                                                                                                                 [ 30%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_demultiplexing_required_false PASSED                                                                                                                                                                                [ 35%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_valid_samplesheet_pass PASSED                                                                                                                                                                                       [ 40%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_valid_samplesheet_fail PASSED                                                                                                                                                                                       [ 45%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_sequencing_complete_pass PASSED                                                                                                                                                                                     [ 50%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_sequencing_complete_fail PASSED                                                                                                                                                                                     [ 55%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_seq_requires_no_ic_pass PASSED                                                                                                                                                                                      [ 60%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_seq_requires_no_ic_fail PASSED                                                                                                                                                                                      [ 65%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_pass_integrity_check_pass PASSED                                                                                                                                                                                    [ 70%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_pass_integrity_check_fail PASSED                                                                                                                                                                                    [ 75%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_create_demultiplexlog_success PASSED                                                                                                                                                                                [ 80%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_create_demultiplexlog_fail PASSED                                                                                                                                                                                   [ 85%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_add_demultiplexlog_msg_pass PASSED                                                                                                                                                                                  [ 90%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_calculate_cluster_density_pass PASSED                                                                                                                                                                               [ 95%]
demultiplex/test_demultiplex.py::TestDemultiplexRunfolder::test_calculate_cluster_density_fail PASSED                                                                                                                                                                               [100%]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/630)
<!-- Reviewable:end -->
