### PR TITLE
bugfix capture pan cp2

### DIFF
--- a/config/panel_config.py
+++ b/config/panel_config.py
@@ -861,6 +861,5 @@ class PanelConfig:
     and v.get("congenica_credentials", "").strip() == "STG"
 ]
     CP_CAPTURE_PANNOS = [
-        CAPTURE_PANEL_DICT["vcp1"]["capture_pan_num"],
-        CAPTURE_PANEL_DICT["CP2"]["capture_pan_num"],
+        CAPTURE_PANEL_DICT["vcp1"]["capture_pan_num"]
     ]


### PR DESCRIPTION
Previously capture pan number was removed for CP205 pipeline since it was not needed. But I missed to remove it in another line of code which failed AS. To fix the bug, `CAPTURE_PANEL_DICT["CP2"]["capture_pan_num"],` was removed.
Tests were done after removing this line and it was confirmed the bug was fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/633)
<!-- Reviewable:end -->
