### PR TITLE
Feature/exclude failed fastqs from okd

### DIFF
--- a/config/log_msgs_config.py
+++ b/config/log_msgs_config.py
@@ -164,6 +164,7 @@ LOG_MSGS = {
         "not_fastq": "File is not a zipped fastq: %s",
         "undetermined_identified": "Undetermined file identified to exclude from processing: %s",
         "sample_excluded_failed_fastq": "Sample excluded from seglh_pipe commands due to failed fastq validation: %s",
+        "fastq_excluded_oncodeep": "Fastq excluded from OncoDEEP upload command due to failed fastq validation: %s",
     },
     "backup": {
         "checking_runfolder": "Checking the runfolder exists: %s",

--- a/config/log_msgs_config.py
+++ b/config/log_msgs_config.py
@@ -164,7 +164,7 @@ LOG_MSGS = {
         "not_fastq": "File is not a zipped fastq: %s",
         "undetermined_identified": "Undetermined file identified to exclude from processing: %s",
         "sample_excluded_failed_fastq": "Sample excluded from seglh_pipe commands due to failed fastq validation: %s",
-        "fastq_excluded_oncodeep": "Fastq excluded from OncoDEEP upload command due to failed fastq validation: %s",
+        "fastq_excluded_oncodeep": "Sample excluded from OncoDEEP upload commands due to failed fastq validation: %s",
     },
     "backup": {
         "checking_runfolder": "Checking the runfolder exists: %s",

--- a/conftest.py
+++ b/conftest.py
@@ -76,6 +76,7 @@ def patch_toolbox(monkeypatch):
     """
     monkeypatch.setattr(toolbox.ToolboxConfig, "RUNFOLDERS", temp_runfolderdir)
     monkeypatch.setattr(toolbox.ToolboxConfig, "AD_LOGDIR", temp_log_dir)
+    monkeypatch.setattr(toolbox, "get_credential", lambda x: "mock_token")
 
 
 def create_logdirs():

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -1144,26 +1144,27 @@ class OncoDeepPipeline:
             self.workflow_cmds.append(SWConfig.UPLOAD_ARGS["depends_list"])
 
             self.sql_queries.append(sample_cmds_obj.return_oncology_query())
-            for read in ["R1", "R2"]:  # Generate sample oncodeep upload commands
-                fastq_name = self.rf_samples_obj.samples_dict[sample_name]["fastqs"][read]["name"]
-                if (
-                    hasattr(self.rf_obj, "failed_fastqs")
-                    and fastq_name in self.rf_obj.failed_fastqs
-                ):
-                    self.logger.warning(
-                        self.logger.log_msgs["fastq_excluded_oncodeep"],
-                        fastq_name,
-                    )
-                    continue
-                self.workflow_cmds.append(
-                    sample_cmds_obj.build_oncodeep_upload_cmd(
-                        f"{sample_name}-{read}",
-                        self.rf_samples_obj.nexus_runfolder_suffix,
-                        self.rf_samples_obj.samples_dict[sample_name]["fastqs"][read][
-                            "nexus_path"
-                        ],
-                    )
+            sample_has_failed_fastq = hasattr(self.rf_obj, "failed_fastqs") and any(
+                self.rf_samples_obj.samples_dict[sample_name]["fastqs"][read]["name"]
+                in self.rf_obj.failed_fastqs
+                for read in ["R1", "R2"]
+            )
+            if sample_has_failed_fastq:
+                self.logger.warning(
+                    self.logger.log_msgs["fastq_excluded_oncodeep"],
+                    sample_name,
                 )
+            else:
+                for read in ["R1", "R2"]:  # Generate sample oncodeep upload commands
+                    self.workflow_cmds.append(
+                        sample_cmds_obj.build_oncodeep_upload_cmd(
+                            f"{sample_name}-{read}",
+                            self.rf_samples_obj.nexus_runfolder_suffix,
+                            self.rf_samples_obj.samples_dict[sample_name]["fastqs"][read][
+                                "nexus_path"
+                            ],
+                        )
+                    )
         # Generate command for MasterFile upload
         self.workflow_cmds.append(
             sample_cmds_obj.build_oncodeep_upload_cmd(

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -1145,6 +1145,16 @@ class OncoDeepPipeline:
 
             self.sql_queries.append(sample_cmds_obj.return_oncology_query())
             for read in ["R1", "R2"]:  # Generate sample oncodeep upload commands
+                fastq_name = self.rf_samples_obj.samples_dict[sample_name]["fastqs"][read]["name"]
+                if (
+                    hasattr(self.rf_obj, "failed_fastqs")
+                    and fastq_name in self.rf_obj.failed_fastqs
+                ):
+                    self.logger.warning(
+                        self.logger.log_msgs["fastq_excluded_oncodeep"],
+                        fastq_name,
+                    )
+                    continue
                 self.workflow_cmds.append(
                     sample_cmds_obj.build_oncodeep_upload_cmd(
                         f"{sample_name}-{read}",

--- a/setoff_workflows/test_setoff_workflows.py
+++ b/setoff_workflows/test_setoff_workflows.py
@@ -2,3 +2,88 @@
 """
 
 # TODO finish this test suite as it is currently incomplete
+
+from unittest.mock import MagicMock, patch
+from setoff_workflows.setoff_workflows import OncoDeepPipeline
+
+
+def _make_rf_obj(failed_fastqs=None):
+    rf_obj = MagicMock()
+    rf_obj.runfolder_name = "999999_A01229_0000_00000OKD1"
+    rf_obj.masterfile_name = "masterfile.txt"
+    rf_obj.DNANEXUS_PROJ_ID = "project-xxx"
+    rf_obj.failed_fastqs = failed_fastqs or []
+    return rf_obj
+
+
+def _make_rf_samples(samples):
+    rf_samples = MagicMock()
+    rf_samples.pipeline = "oncodeep"
+    rf_samples.samples_dict = samples
+    rf_samples.nexus_runfolder_suffix = "OKD1234"
+    return rf_samples
+
+
+def _sample_dict(sample_name):
+    return {
+        "panel_settings": {"pipeline": "oncodeep"},
+        "fastqs": {
+            "R1": {
+                "name": f"{sample_name}_R1_001.fastq.gz",
+                "nexus_path": f"project-xxx:/fastqs/{sample_name}_R1_001.fastq.gz",
+            },
+            "R2": {
+                "name": f"{sample_name}_R2_001.fastq.gz",
+                "nexus_path": f"project-xxx:/fastqs/{sample_name}_R2_001.fastq.gz",
+            },
+        },
+    }
+
+
+def _get_upload_call_args(mock_sample_cmds_cls):
+    return [
+        call.args[0]
+        for call in mock_sample_cmds_cls.return_value.build_oncodeep_upload_cmd.call_args_list
+    ]
+
+
+@patch("setoff_workflows.setoff_workflows.BuildRunfolderDxCommands")
+@patch("setoff_workflows.setoff_workflows.BuildSampleDxCommands")
+def test_failed_r1_excludes_both_reads_from_oncodeep_upload(mock_sample_cmds_cls, mock_rf_cmds_cls):
+    sample_name = "OKD123_S1"
+    rf_obj = _make_rf_obj(failed_fastqs=[f"{sample_name}_R1_001.fastq.gz"])
+    rf_samples = _make_rf_samples({sample_name: _sample_dict(sample_name)})
+
+    OncoDeepPipeline(rf_obj, rf_samples, MagicMock())
+
+    called_with = _get_upload_call_args(mock_sample_cmds_cls)
+    assert f"{sample_name}-R1" not in called_with
+    assert f"{sample_name}-R2" not in called_with
+
+
+@patch("setoff_workflows.setoff_workflows.BuildRunfolderDxCommands")
+@patch("setoff_workflows.setoff_workflows.BuildSampleDxCommands")
+def test_failed_r2_excludes_both_reads_from_oncodeep_upload(mock_sample_cmds_cls, mock_rf_cmds_cls):
+    sample_name = "OKD123_S1"
+    rf_obj = _make_rf_obj(failed_fastqs=[f"{sample_name}_R2_001.fastq.gz"])
+    rf_samples = _make_rf_samples({sample_name: _sample_dict(sample_name)})
+
+    OncoDeepPipeline(rf_obj, rf_samples, MagicMock())
+
+    called_with = _get_upload_call_args(mock_sample_cmds_cls)
+    assert f"{sample_name}-R1" not in called_with
+    assert f"{sample_name}-R2" not in called_with
+
+
+@patch("setoff_workflows.setoff_workflows.BuildRunfolderDxCommands")
+@patch("setoff_workflows.setoff_workflows.BuildSampleDxCommands")
+def test_no_failed_fastqs_both_reads_uploaded(mock_sample_cmds_cls, mock_rf_cmds_cls):
+    sample_name = "OKD123_S1"
+    rf_obj = _make_rf_obj(failed_fastqs=[])
+    rf_samples = _make_rf_samples({sample_name: _sample_dict(sample_name)})
+
+    OncoDeepPipeline(rf_obj, rf_samples, MagicMock())
+
+    called_with = _get_upload_call_args(mock_sample_cmds_cls)
+    assert f"{sample_name}-R1" in called_with
+    assert f"{sample_name}-R2" in called_with


### PR DESCRIPTION
Logic to exclude samples with failed fastqs from OKD uploads

- In `OncoDeepPipeline`, check whether either R1 or R2 fastq for a sample has failed validation before appending upload commands to workflow_cmds. If either read has failed, both are excluded and a warning is logged. Mirrors the existing logic in `CustomPanelsPipelines` for seglh_pipe/gatk_pipe runs
- Added `fastq_excluded_oncodeep` log message to `log_msgs_config.py`
- Patched `get_credential` in `patch_toolbox` so tests no longer require a DNAnexus auth token file to exist on the system. The credential is not exercised by any test and change should make testing safer/easier locally.
- Initial creation of `test_setoff_workflows.py`. Added mock OKD scenarios specific to this PR, can be used to generate future unit tests to simplify testing process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/637)
<!-- Reviewable:end -->
