### PR TITLE
Redirect data to amzn s3

### DIFF
--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -122,9 +122,12 @@ S3_BUCKETS = {
     "msk": "msk-access-archive",
     "archerdx": "archer-ngs-archive",
 }
-# AWS CLI upload command for S3:
-#   %s = local file path, %s = s3 destination URI, %s = AWS CLI profile name
-S3_UPLOAD_CMD = "aws s3 cp %s %s --profile %s --storage-class DEEP_ARCHIVE"
+# AWS CLI upload commands for S3:
+#   %s = local path, %s = s3 destination URI, %s = AWS CLI profile name
+# Per-file copy (used for individual files e.g. logfiles)
+S3_CP_CMD = "aws s3 cp %s %s --profile %s --storage-class DEEP_ARCHIVE"
+# Directory sync (used for whole-runfolder uploads)
+S3_SYNC_CMD = "aws s3 sync %s %s --profile %s --storage-class DEEP_ARCHIVE"
 
 # -------------- DNANEXUS-SPECIFIC --------------------------------------------------------------
 
@@ -487,7 +490,8 @@ class SWConfig(PanelConfig):
         TSO_BATCH_SIZE = 2
     S3_PIPELINES = S3_PIPELINES
     S3_BUCKETS = S3_BUCKETS
-    S3_UPLOAD_CMD = S3_UPLOAD_CMD
+    S3_CP_CMD = S3_CP_CMD
+    S3_SYNC_CMD = S3_SYNC_CMD
     RUNFOLDER_NAME = "${RUNFOLDER_NAME}"
     EMPTY_DEPENDS = "DEPENDS_LIST=''"
     EMPTY_CP_DEPENDS = [

--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -82,8 +82,7 @@ CREDENTIALS = {
     "email_pw": os.path.join(DOCUMENT_ROOT, ".amazon_email_pw"),
     "dnanexus_authtoken": os.path.join(DOCUMENT_ROOT, ".dnanexus_auth_token"),
     "adx_authtoken": ".archer_authentication_mokaguys.txt",
-    # Path to file containing the AWS CLI profile name used for S3 uploads (msk/archerdx pipelines)
-    "aws_s3_profile": os.path.join(DOCUMENT_ROOT, ".aws_s3_profile"),
+    "aws_s3_profile": os.path.join(DOCUMENT_ROOT, ".aws_s3_profile"), # AWS CLI profile name for S3 uploads
 }
 NOVASEQ_ID = "A01229"  # Novaseq sequencer ID
 AVITI01_ID = "AV241501" # Aviti sequencer ID
@@ -116,15 +115,14 @@ AVITI_DEMULTIPLEX_SUCCESS = "Output stored in /output"
 
 # -------------- S3-SPECIFIC ------------------------------------------------------------------
 
-# Pipelines whose data is uploaded to S3 instead of DNAnexus
+# For S3 uploads
 S3_PIPELINES = ["msk", "archerdx"]
-# Per-pipeline S3 bucket names
-# S3 bucket name for each pipeline
+# S3 buckets
 S3_BUCKETS = {
     "msk": "s3://msk-access-archive",
     "archerdx": "s3://archer-ngs-archive",
 }
-# AWS CLI command for uploading a single file to S3:
+# AWS CLI upload command for S3:
 #   %s = local file path, %s = s3 destination URI, %s = AWS CLI profile name
 S3_UPLOAD_CMD = "aws s3 cp %s %s --profile %s --storage-class DEEP_ARCHIVE"
 

--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -118,9 +118,12 @@ AVITI_DEMULTIPLEX_SUCCESS = "Output stored in /output"
 
 # Pipelines whose data is uploaded to S3 instead of DNAnexus
 S3_PIPELINES = ["msk", "archerdx"]
-# S3 bucket name for msk/archerdx data upload
-# TODO: Set the target S3 bucket name here
-S3_BUCKET = "TODO_SET_S3_BUCKET_NAME"
+# Per-pipeline S3 bucket names
+# S3 bucket name for each pipeline
+S3_BUCKETS = {
+    "msk": "TODO_SET_MSK_S3_BUCKET_NAME",
+    "archerdx": "TODO_SET_ARCHERDX_S3_BUCKET_NAME",
+}
 # AWS CLI command for uploading a single file to S3:
 #   %s = local file path, %s = s3 destination URI, %s = AWS CLI profile name
 S3_UPLOAD_CMD = "aws s3 cp %s %s --profile %s"
@@ -485,7 +488,7 @@ class SWConfig(PanelConfig):
         }
         TSO_BATCH_SIZE = 2
     S3_PIPELINES = S3_PIPELINES
-    S3_BUCKET = S3_BUCKET
+    S3_BUCKETS = S3_BUCKETS
     S3_UPLOAD_CMD = S3_UPLOAD_CMD
     RUNFOLDER_NAME = "${RUNFOLDER_NAME}"
     EMPTY_DEPENDS = "DEPENDS_LIST=''"

--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -81,7 +81,9 @@ CREDENTIALS = {
     "email_user": os.path.join(DOCUMENT_ROOT, ".amazon_email_username"),
     "email_pw": os.path.join(DOCUMENT_ROOT, ".amazon_email_pw"),
     "dnanexus_authtoken": os.path.join(DOCUMENT_ROOT, ".dnanexus_auth_token"),
-    "adx_authtoken": ".archer_authentication_mokaguys.txt"
+    "adx_authtoken": ".archer_authentication_mokaguys.txt",
+    # Path to file containing the AWS CLI profile name used for S3 uploads (msk/archerdx pipelines)
+    "aws_s3_profile": os.path.join(DOCUMENT_ROOT, ".aws_s3_profile"),
 }
 NOVASEQ_ID = "A01229"  # Novaseq sequencer ID
 AVITI01_ID = "AV241501" # Aviti sequencer ID
@@ -111,6 +113,17 @@ LANE_METRICS_SUFFIX = ".illumina_lane_metrics"
 DEMUX_NOT_REQUIRED_MSG = "%s run. Does not need demultiplexing locally"
 ILLUMINA_DEMULTIPLEX_SUCCESS = "thread 1 Conversion Complete."
 AVITI_DEMULTIPLEX_SUCCESS = "Output stored in /output"
+
+# -------------- S3-SPECIFIC ------------------------------------------------------------------
+
+# Pipelines whose data is uploaded to S3 instead of DNAnexus
+S3_PIPELINES = ["msk", "archerdx"]
+# S3 bucket name for msk/archerdx data upload
+# TODO: Set the target S3 bucket name here
+S3_BUCKET = "TODO_SET_S3_BUCKET_NAME"
+# AWS CLI command for uploading a single file to S3:
+#   %s = local file path, %s = s3 destination URI, %s = AWS CLI profile name
+S3_UPLOAD_CMD = "aws s3 cp %s %s --profile %s"
 
 # -------------- DNANEXUS-SPECIFIC --------------------------------------------------------------
 
@@ -471,6 +484,9 @@ class SWConfig(PanelConfig):
             "admins": [PROD_ORGANISATION],
         }
         TSO_BATCH_SIZE = 2
+    S3_PIPELINES = S3_PIPELINES
+    S3_BUCKET = S3_BUCKET
+    S3_UPLOAD_CMD = S3_UPLOAD_CMD
     RUNFOLDER_NAME = "${RUNFOLDER_NAME}"
     EMPTY_DEPENDS = "DEPENDS_LIST=''"
     EMPTY_CP_DEPENDS = [

--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -121,12 +121,12 @@ S3_PIPELINES = ["msk", "archerdx"]
 # Per-pipeline S3 bucket names
 # S3 bucket name for each pipeline
 S3_BUCKETS = {
-    "msk": "TODO_SET_MSK_S3_BUCKET_NAME",
-    "archerdx": "TODO_SET_ARCHERDX_S3_BUCKET_NAME",
+    "msk": "s3://msk-access-archive",
+    "archerdx": "s3://archer-ngs-archive",
 }
 # AWS CLI command for uploading a single file to S3:
 #   %s = local file path, %s = s3 destination URI, %s = AWS CLI profile name
-S3_UPLOAD_CMD = "aws s3 cp %s %s --profile %s"
+S3_UPLOAD_CMD = "aws s3 cp %s %s --profile %s --storage-class DEEP_ARCHIVE"
 
 # -------------- DNANEXUS-SPECIFIC --------------------------------------------------------------
 

--- a/config/ad_config.py
+++ b/config/ad_config.py
@@ -119,8 +119,8 @@ AVITI_DEMULTIPLEX_SUCCESS = "Output stored in /output"
 S3_PIPELINES = ["msk", "archerdx"]
 # S3 buckets
 S3_BUCKETS = {
-    "msk": "s3://msk-access-archive",
-    "archerdx": "s3://archer-ngs-archive",
+    "msk": "msk-access-archive",
+    "archerdx": "archer-ngs-archive",
 }
 # AWS CLI upload command for S3:
 #   %s = local file path, %s = s3 destination URI, %s = AWS CLI profile name

--- a/config/log_msgs_config.py
+++ b/config/log_msgs_config.py
@@ -132,6 +132,7 @@ LOG_MSGS = {
         "uploading_files": "Uploading %s files",
         "upload_success": "%s files uploaded successfully",
         "upload_fail": "%s upload failed. See %s for detailed error log",
+        "s3_upload_fail": "S3 upload failed for %s. Stderr: %s",
         "building_cmds": "Building dx run commands",
         "splitting_tso_samplesheet": "Splitting SampleSheet for TSO run into batches containing %s samples each: %s",
         "tso_batches_count": "Creating %s SampleSheets",

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -917,6 +917,35 @@ class ProcessRunfolder(SWConfig):
             )
             sys.exit(1)
 
+    def upload_rest_of_runfolder_s3(self) -> None:
+        """
+        Uploads all remaining runfolder files to S3 (excluding BCL directories),
+        preserving the relative directory structure under the runfolder name
+            :return None:
+        """
+        aws_profile = get_credential(SWConfig.CREDENTIALS["aws_s3_profile"])
+        s3_bucket = SWConfig.S3_BUCKETS[self.rf_samples_obj.pipeline]
+        for dirpath, dirnames, filenames in os.walk(self.rf_obj.runfolderpath):
+            dirnames[:] = [d for d in dirnames if not d.startswith("L00")]  # Exclude BCL dirs
+            for filename in filenames:
+                filepath = os.path.join(dirpath, filename)
+                rel_path = os.path.relpath(filepath, self.rf_obj.runfolderpath)
+                s3_dest = f"s3://{s3_bucket}/{self.rf_obj.runfolder_name}/{rel_path}"
+                cmd = SWConfig.S3_UPLOAD_CMD % (filepath, s3_dest, aws_profile)
+                _, err, returncode = execute_subprocess_command(
+                    cmd, self.loggers["sw"], "exit_on_fail"
+                )
+                if returncode == 0:
+                    self.loggers["sw"].info(
+                        self.loggers["sw"].log_msgs["upload_success"], filename
+                    )
+                else:
+                    self.loggers["sw"].error(
+                        self.loggers["sw"].log_msgs["s3_upload_fail"],
+                        filename,
+                        err,
+                    )
+
     def run_decision_support_commands(self) -> None:
         """
         Execute the decision_support bash script
@@ -990,6 +1019,7 @@ class ProcessRunfolder(SWConfig):
             :return None:
         """
         if self.rf_samples_obj.pipeline in SWConfig.S3_PIPELINES:
+            self.upload_rest_of_runfolder_s3()
             self.upload_to_s3("logfiles", self.s3_upload_dict)
         else:
             if self.rf_samples_obj.pipeline != "tso500":

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -823,7 +823,7 @@ class ProcessRunfolder(SWConfig):
                 f"{s3_upload_dict[filetype]['s3_prefix']}"
                 f"{os.path.basename(filepath)}"
             )
-            cmd = SWConfig.S3_UPLOAD_CMD % (filepath, s3_dest, aws_profile)
+            cmd = SWConfig.S3_CP_CMD % (filepath, s3_dest, aws_profile)
             _, err, returncode = execute_subprocess_command(
                 cmd, self.loggers["sw"], "exit_on_fail"
             )
@@ -873,32 +873,33 @@ class ProcessRunfolder(SWConfig):
 
     def upload_rest_of_runfolder_s3(self) -> None:
         """
-        Uploads all remaining runfolder files to S3 (excluding BCL directories),
-        preserving the relative directory structure under the runfolder name
+        Uploads the runfolder directory to S3 using aws s3 sync, excluding BCL
+        directories (L00*). Preserves the directory structure under the runfolder name
             :return None:
         """
         aws_profile = get_credential(SWConfig.CREDENTIALS["aws_s3_profile"])
         s3_bucket = SWConfig.S3_BUCKETS[self.rf_samples_obj.pipeline]
-        for dirpath, dirnames, filenames in os.walk(self.rf_obj.runfolderpath):
-            dirnames[:] = [d for d in dirnames if not d.startswith("L00")]  # Exclude BCL dirs
-            for filename in filenames:
-                filepath = os.path.join(dirpath, filename)
-                rel_path = os.path.relpath(filepath, self.rf_obj.runfolderpath)
-                s3_dest = f"s3://{s3_bucket}/{self.rf_obj.runfolder_name}/{rel_path}"
-                cmd = SWConfig.S3_UPLOAD_CMD % (filepath, s3_dest, aws_profile)
-                _, err, returncode = execute_subprocess_command(
-                    cmd, self.loggers["sw"], "exit_on_fail"
-                )
-                if returncode == 0:
-                    self.loggers["sw"].info(
-                        self.loggers["sw"].log_msgs["upload_success"], filename
-                    )
-                else:
-                    self.loggers["sw"].error(
-                        self.loggers["sw"].log_msgs["s3_upload_fail"],
-                        filename,
-                        err,
-                    )
+        s3_dest = f"s3://{s3_bucket}/{self.rf_obj.runfolder_name}"
+        cmd = (
+            SWConfig.S3_SYNC_CMD % (self.rf_obj.runfolderpath, s3_dest, aws_profile)
+            + " --exclude 'L00*'"
+        )
+        self.loggers["sw"].info(
+            self.loggers["sw"].log_msgs["uploading_files"], "runfolder"
+        )
+        _, err, returncode = execute_subprocess_command(
+            cmd, self.loggers["sw"], "exit_on_fail"
+        )
+        if returncode == 0:
+            self.loggers["sw"].info(
+                self.loggers["sw"].log_msgs["upload_success"], "runfolder"
+            )
+        else:
+            self.loggers["sw"].error(
+                self.loggers["sw"].log_msgs["s3_upload_fail"],
+                self.rf_obj.runfolder_name,
+                err,
+            )
 
     def run_decision_support_commands(self) -> None:
         """

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -345,10 +345,10 @@ class ProcessRunfolder(SWConfig):
                         list(filter(None, self.pipeline_obj.decision_support_upload_cmds)),
                     )
 
-        #if self.rf_samples_obj.pipeline == "archerdx":
-        #    self.run_decision_support_commands()
-        #elif self.rf_samples_obj.pipeline == "msk":
-        #    self.run_msk_commands()
+        if self.rf_samples_obj.pipeline == "archerdx":
+            self.run_decision_support_commands()
+        elif self.rf_samples_obj.pipeline == "msk":
+            self.run_msk_commands()
         self.pipeline_emails = PipelineEmails(
             self.rf_obj,
             self.rf_samples_obj,

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -984,9 +984,14 @@ class ProcessRunfolder(SWConfig):
         """
         if self.rf_samples_obj.pipeline in SWConfig.S3_PIPELINES:
             self.upload_rest_of_runfolder_s3()
+            # Filter out upload_runfolder_logfile as it's not created for S3 pipelines
+            logfiles_to_upload = [
+                f for f in self.rf_obj.logfiles_to_upload 
+                if f != self.rf_obj.upload_runfolder_logfile
+            ]
             logfiles_s3_dict = {
                 "logfiles": {
-                    "files_list": self.rf_obj.logfiles_to_upload,
+                    "files_list": logfiles_to_upload,
                     "s3_prefix": f"{self.rf_obj.runfolder_name}/logfiles/",
                 }
             }

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -801,7 +801,7 @@ class ProcessRunfolder(SWConfig):
 
     def create_s3_file_upload_dict(self) -> dict:
         """
-        Create dictionary of files to upload to S3 for pipelines that use S3 instead of DNAnexus.
+        Create dictionary of files to upload to S3 for pipelines that use S3 storage instead of DNAnexus.
         Includes samplesheet, fastqs, and logfiles
             :return s3_upload_dict (dict):  Dict of files and S3 destination prefixes, keyed by
                                             file type
@@ -843,8 +843,9 @@ class ProcessRunfolder(SWConfig):
                     self.loggers["sw"].log_msgs["nonexistent_files"], filepath
                 )
                 continue
+            s3_bucket = SWConfig.S3_BUCKETS[self.rf_samples_obj.pipeline]
             s3_dest = (
-                f"s3://{SWConfig.S3_BUCKET}/"
+                f"s3://{s3_bucket}/"
                 f"{s3_upload_dict[filetype]['s3_prefix']}"
                 f"{os.path.basename(filepath)}"
             )
@@ -865,7 +866,7 @@ class ProcessRunfolder(SWConfig):
 
     def pre_pipeline_upload_s3(self) -> None:
         """
-        Uploads the samplesheet and fastqs to S3 for pipelines that use S3 instead of DNAnexus
+        Uploads the samplesheet and fastqs to S3 for pipelines that use S3 instead of DNAnexus as storage
             :return None:
         """
         for filetype in ("runfolder_samplesheet", "fastqs"):

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -304,34 +304,39 @@ class ProcessRunfolder(SWConfig):
         """
         self.rf_obj = rf_obj
         self.loggers = loggers
-        self.dnanexus_auth = get_credential(SWConfig.CREDENTIALS["dnanexus_authtoken"])
         open(
             self.rf_obj.upload_flagfile, "w"
         ).close()  # Create upload flag file (prevents processing by other script runs)
         self.rf_samples_obj = RunfolderSamples(self.rf_obj, self.loggers["sw"])
-        self.users_dict = self.get_users_dict()
-        self.write_project_creation_script()
-        self.nexus_identifiers = {
-            "proj_name": self.rf_samples_obj.nexus_paths["proj_name"],
-            "proj_id": self.run_project_creation_script(),
-        }
-        self.upload_runfolder = UploadRunfolder(
-            self.loggers["backup"],
-            self.rf_obj.runfolder_name,
-            self.rf_obj.runfolderpath,
-            self.rf_obj.upload_flagfile,
-            self.nexus_identifiers,
-        )
-        self.upload_cmds = self.get_upload_cmds()
-        self.pre_pipeline_upload_dict = self.create_file_upload_dict()
-        self.pipeline_obj = self.build_dx_commands()
-        self.write_dx_run_cmds()
-        self.pre_pipeline_upload()
-        
-        # Skip run_dx_run_commands for MSK pipeline
-        if self.rf_samples_obj.pipeline != "msk":
+
+        if self.rf_samples_obj.pipeline not in SWConfig.S3_PIPELINES:
+            # DNAnexus path: create project, upload files to DNAnexus, run dx commands
+            self.dnanexus_auth = get_credential(SWConfig.CREDENTIALS["dnanexus_authtoken"])
+            self.users_dict = self.get_users_dict()
+            self.write_project_creation_script()
+            self.nexus_identifiers = {
+                "proj_name": self.rf_samples_obj.nexus_paths["proj_name"],
+                "proj_id": self.run_project_creation_script(),
+            }
+            self.upload_runfolder = UploadRunfolder(
+                self.loggers["backup"],
+                self.rf_obj.runfolder_name,
+                self.rf_obj.runfolderpath,
+                self.rf_obj.upload_flagfile,
+                self.nexus_identifiers,
+            )
+            self.upload_cmds = self.get_upload_cmds()
+            self.pre_pipeline_upload_dict = self.create_file_upload_dict()
+            self.pipeline_obj = self.build_dx_commands()
+            self.write_dx_run_cmds()
+            self.pre_pipeline_upload()
             self.run_dx_run_commands()
-        
+        else:
+            # S3 path: upload files to S3, skip all DNAnexus project/upload steps
+            self.pipeline_obj = self.build_dx_commands()
+            self.s3_upload_dict = self.create_s3_file_upload_dict()
+            self.pre_pipeline_upload_s3()
+
         if self.rf_samples_obj.pipeline == "archerdx":
             self.run_decision_support_commands()
         elif self.rf_samples_obj.pipeline == "msk":
@@ -794,6 +799,78 @@ class ProcessRunfolder(SWConfig):
                 self.loggers["sw"].log_msgs["nonexistent_files"], result
             )
 
+    def create_s3_file_upload_dict(self) -> dict:
+        """
+        Create dictionary of files to upload to S3 for pipelines that use S3 instead of DNAnexus.
+        Includes samplesheet, fastqs, and logfiles
+            :return s3_upload_dict (dict):  Dict of files and S3 destination prefixes, keyed by
+                                            file type
+        """
+        return {
+            "runfolder_samplesheet": {
+                "files_list": [self.rf_obj.runfolder_samplesheet_path],
+                "s3_prefix": f"{self.rf_obj.runfolder_name}/",
+            },
+            "fastqs": {
+                "files_list": [
+                    *self.rf_samples_obj.fastqs_list,
+                    *self.rf_samples_obj.undetermined_fastqs_list,
+                ],
+                "s3_prefix": f"{self.rf_obj.runfolder_name}/fastqs/",
+            },
+            "logfiles": {
+                "files_list": self.rf_obj.logfiles_to_upload,
+                "s3_prefix": f"{self.rf_obj.runfolder_name}/logfiles/",
+            },
+        }
+
+    def upload_to_s3(self, filetype: str, s3_upload_dict: dict) -> None:
+        """
+        Uploads files to the configured S3 bucket using the AWS CLI. The AWS profile
+        name is read from the credential file at SWConfig.CREDENTIALS["aws_s3_profile"].
+        Files that do not exist locally are skipped with an error log
+            :param filetype (str):          Name of the file upload type
+            :param s3_upload_dict (dict):   Dictionary of files and S3 prefixes for upload
+            :return None:
+        """
+        self.loggers["sw"].info(
+            self.loggers["sw"].log_msgs["uploading_files"], filetype
+        )
+        aws_profile = get_credential(SWConfig.CREDENTIALS["aws_s3_profile"])
+        for filepath in s3_upload_dict[filetype]["files_list"]:
+            if not os.path.exists(filepath):
+                self.loggers["sw"].error(
+                    self.loggers["sw"].log_msgs["nonexistent_files"], filepath
+                )
+                continue
+            s3_dest = (
+                f"s3://{SWConfig.S3_BUCKET}/"
+                f"{s3_upload_dict[filetype]['s3_prefix']}"
+                f"{os.path.basename(filepath)}"
+            )
+            cmd = SWConfig.S3_UPLOAD_CMD % (filepath, s3_dest, aws_profile)
+            _, err, returncode = execute_subprocess_command(
+                cmd, self.loggers["sw"], "exit_on_fail"
+            )
+            if returncode == 0:
+                self.loggers["sw"].info(
+                    self.loggers["sw"].log_msgs["upload_success"], filetype
+                )
+            else:
+                self.loggers["sw"].error(
+                    self.loggers["sw"].log_msgs["s3_upload_fail"],
+                    filetype,
+                    err,
+                )
+
+    def pre_pipeline_upload_s3(self) -> None:
+        """
+        Uploads the samplesheet and fastqs to S3 for pipelines that use S3 instead of DNAnexus
+            :return None:
+        """
+        for filetype in ("runfolder_samplesheet", "fastqs"):
+            self.upload_to_s3(filetype, self.s3_upload_dict)
+
     def upload_rest_of_runfolder(self) -> None:
         """
         Backs up the rest of the runfolder. Specifies which files to ignore (excludes BCL files for all Illumina
@@ -895,20 +972,24 @@ class ProcessRunfolder(SWConfig):
 
     def post_pipeline_upload(self) -> None:
         """
-        Uploads the rest of the runfolder if not a tso run
+        Uploads the rest of the runfolder if not a tso run. For S3 pipelines, uploads
+        logfiles to S3 instead of DNAnexus
             :return None:
         """
-        if self.rf_samples_obj.pipeline != "tso500":
-            self.upload_rest_of_runfolder()
+        if self.rf_samples_obj.pipeline in SWConfig.S3_PIPELINES:
+            self.upload_to_s3("logfiles", self.s3_upload_dict)
+        else:
+            if self.rf_samples_obj.pipeline != "tso500":
+                self.upload_rest_of_runfolder()
 
-        logfiles_upload_dict = {
-            "logfiles": {
-                "cmd": self.upload_cmds["logfiles"],
-                "files_list": self.rf_obj.logfiles_to_upload,
-            },
-        }
-        for filetype in logfiles_upload_dict.keys():  # Upload logfiles for all runtypes
-            self.upload_to_dnanexus(filetype, logfiles_upload_dict)
+            logfiles_upload_dict = {
+                "logfiles": {
+                    "cmd": self.upload_cmds["logfiles"],
+                    "files_list": self.rf_obj.logfiles_to_upload,
+                },
+            }
+            for filetype in logfiles_upload_dict.keys():  # Upload logfiles for all runtypes
+                self.upload_to_dnanexus(filetype, logfiles_upload_dict)
 
     def run_msk_commands(self):
         """Execute MSK pipeline commands directly without any DNAnexus interaction"""

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -826,7 +826,7 @@ class ProcessRunfolder(SWConfig):
 
     def upload_to_s3(self, filetype: str, s3_upload_dict: dict) -> None:
         """
-        Uploads files to the configured S3 bucket using the AWS CLI. The AWS profile
+        Uploads files to the configured S3 buckets using the AWS CLI. The AWS profile
         name is read from the credential file at SWConfig.CREDENTIALS["aws_s3_profile"].
         Files that do not exist locally are skipped with an error log
             :param filetype (str):          Name of the file upload type

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -335,11 +335,20 @@ class ProcessRunfolder(SWConfig):
             # S3 path: skip all DNAnexus project/upload steps; full runfolder
             # is archived to S3 in post_pipeline_upload
             self.pipeline_obj = self.build_dx_commands()
+            if self.rf_samples_obj.pipeline == "archerdx":
+                # Write decision support script without DNAnexus base vars (not
+                # available in the S3 path), as the archerdx commands don't need them
+                if self.pipeline_obj.decision_support_upload_cmds:
+                    write_lines(
+                        self.rf_obj.decision_support_upload_script,
+                        "w",
+                        list(filter(None, self.pipeline_obj.decision_support_upload_cmds)),
+                    )
 
-        if self.rf_samples_obj.pipeline == "archerdx":
-            self.run_decision_support_commands()
-        elif self.rf_samples_obj.pipeline == "msk":
-            self.run_msk_commands()
+        #if self.rf_samples_obj.pipeline == "archerdx":
+        #    self.run_decision_support_commands()
+        #elif self.rf_samples_obj.pipeline == "msk":
+        #    self.run_msk_commands()
         self.pipeline_emails = PipelineEmails(
             self.rf_obj,
             self.rf_samples_obj,

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -332,10 +332,9 @@ class ProcessRunfolder(SWConfig):
             self.pre_pipeline_upload()
             self.run_dx_run_commands()
         else:
-            # S3 path: upload files to S3, skip all DNAnexus project/upload steps
+            # S3 path: skip all DNAnexus project/upload steps; full runfolder
+            # is archived to S3 in post_pipeline_upload
             self.pipeline_obj = self.build_dx_commands()
-            self.s3_upload_dict = self.create_s3_file_upload_dict()
-            self.pre_pipeline_upload_s3()
 
         if self.rf_samples_obj.pipeline == "archerdx":
             self.run_decision_support_commands()
@@ -799,41 +798,6 @@ class ProcessRunfolder(SWConfig):
                 self.loggers["sw"].log_msgs["nonexistent_files"], result
             )
 
-    def create_s3_file_upload_dict(self) -> dict:
-        """
-        Create dictionary of files to upload to S3 for pipelines that use S3 storage instead of DNAnexus.
-        Includes samplesheet, fastqs, logfiles, and QC files for non-AVITI sequencers
-            :return s3_upload_dict (dict):  Dict of files and S3 destination prefixes, keyed by
-                                            file type
-        """
-        s3_upload_dict = {
-            "runfolder_samplesheet": {
-                "files_list": [self.rf_obj.runfolder_samplesheet_path],
-                "s3_prefix": f"{self.rf_obj.runfolder_name}/",
-            },
-            "fastqs": {
-                "files_list": [
-                    *self.rf_samples_obj.fastqs_list,
-                    *self.rf_samples_obj.undetermined_fastqs_list,
-                ],
-                "s3_prefix": f"{self.rf_obj.runfolder_name}/fastqs/",
-            },
-            "logfiles": {
-                "files_list": self.rf_obj.logfiles_to_upload,
-                "s3_prefix": f"{self.rf_obj.runfolder_name}/logfiles/",
-            },
-        }
-        if self.rf_obj.sequencer_type not in SWConfig.AVITI_IDS:
-            s3_upload_dict["bclconvert_qc"] = {
-                "files_list": self.rf_obj.bclconvertstats_file,
-                "s3_prefix": f"{self.rf_obj.runfolder_name}/QC/bclconvert/",
-            }
-            s3_upload_dict["cluster_density"] = {
-                "files_list": self.rf_obj.cluster_density_files,
-                "s3_prefix": f"{self.rf_obj.runfolder_name}/QC/",
-            }
-        return s3_upload_dict
-
     def upload_to_s3(self, filetype: str, s3_upload_dict: dict) -> None:
         """
         Uploads files to the configured S3 buckets using the AWS CLI. The AWS profile
@@ -873,16 +837,6 @@ class ProcessRunfolder(SWConfig):
                     filetype,
                     err,
                 )
-
-    def pre_pipeline_upload_s3(self) -> None:
-        """
-        Uploads all pre-pipeline files (samplesheet, fastqs, and QC files where applicable) to S3
-        for pipelines that use S3 instead of DNAnexus as storage
-            :return None:
-        """
-        for filetype in self.s3_upload_dict:
-            if filetype != "logfiles":
-                self.upload_to_s3(filetype, self.s3_upload_dict)
 
     def upload_rest_of_runfolder(self) -> None:
         """
@@ -1020,7 +974,13 @@ class ProcessRunfolder(SWConfig):
         """
         if self.rf_samples_obj.pipeline in SWConfig.S3_PIPELINES:
             self.upload_rest_of_runfolder_s3()
-            self.upload_to_s3("logfiles", self.s3_upload_dict)
+            logfiles_s3_dict = {
+                "logfiles": {
+                    "files_list": self.rf_obj.logfiles_to_upload,
+                    "s3_prefix": f"{self.rf_obj.runfolder_name}/logfiles/",
+                }
+            }
+            self.upload_to_s3("logfiles", logfiles_s3_dict)
         else:
             if self.rf_samples_obj.pipeline != "tso500":
                 self.upload_rest_of_runfolder()

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -802,11 +802,11 @@ class ProcessRunfolder(SWConfig):
     def create_s3_file_upload_dict(self) -> dict:
         """
         Create dictionary of files to upload to S3 for pipelines that use S3 storage instead of DNAnexus.
-        Includes samplesheet, fastqs, and logfiles
+        Includes samplesheet, fastqs, logfiles, and QC files for non-AVITI sequencers
             :return s3_upload_dict (dict):  Dict of files and S3 destination prefixes, keyed by
                                             file type
         """
-        return {
+        s3_upload_dict = {
             "runfolder_samplesheet": {
                 "files_list": [self.rf_obj.runfolder_samplesheet_path],
                 "s3_prefix": f"{self.rf_obj.runfolder_name}/",
@@ -823,6 +823,16 @@ class ProcessRunfolder(SWConfig):
                 "s3_prefix": f"{self.rf_obj.runfolder_name}/logfiles/",
             },
         }
+        if self.rf_obj.sequencer_type not in SWConfig.AVITI_IDS:
+            s3_upload_dict["bclconvert_qc"] = {
+                "files_list": self.rf_obj.bclconvertstats_file,
+                "s3_prefix": f"{self.rf_obj.runfolder_name}/QC/bclconvert/",
+            }
+            s3_upload_dict["cluster_density"] = {
+                "files_list": self.rf_obj.cluster_density_files,
+                "s3_prefix": f"{self.rf_obj.runfolder_name}/QC/",
+            }
+        return s3_upload_dict
 
     def upload_to_s3(self, filetype: str, s3_upload_dict: dict) -> None:
         """
@@ -866,11 +876,13 @@ class ProcessRunfolder(SWConfig):
 
     def pre_pipeline_upload_s3(self) -> None:
         """
-        Uploads the samplesheet and fastqs to S3 for pipelines that use S3 instead of DNAnexus as storage
+        Uploads all pre-pipeline files (samplesheet, fastqs, and QC files where applicable) to S3
+        for pipelines that use S3 instead of DNAnexus as storage
             :return None:
         """
-        for filetype in ("runfolder_samplesheet", "fastqs"):
-            self.upload_to_s3(filetype, self.s3_upload_dict)
+        for filetype in self.s3_upload_dict:
+            if filetype != "logfiles":
+                self.upload_to_s3(filetype, self.s3_upload_dict)
 
     def upload_rest_of_runfolder(self) -> None:
         """

--- a/setoff_workflows/setoff_workflows.py
+++ b/setoff_workflows/setoff_workflows.py
@@ -891,7 +891,7 @@ class ProcessRunfolder(SWConfig):
         s3_dest = f"s3://{s3_bucket}/{self.rf_obj.runfolder_name}"
         cmd = (
             SWConfig.S3_SYNC_CMD % (self.rf_obj.runfolderpath, s3_dest, aws_profile)
-            + " --exclude 'L00*'"
+            + " --exclude '*/L00*/*'"
         )
         self.loggers["sw"].info(
             self.loggers["sw"].log_msgs["uploading_files"], "runfolder"


### PR DESCRIPTION
Data for Archer and MSK runs are now uploaded to two distinct Amazon S3 buckets instead of DNAnexus, this was functionally implemented by:
- Creating a condition in setoff_workflows.py for S3 pipelines which skips DNAnexus pipeline upload steps but initiates the equivalent steps of the DNAnexus upload but instead for Amazon s3 such as s3_upload dictionary, s3 pre_pipeline upload and s3_upload. Post_pipeline_upload is also updated where s3 pipeline log files are uploaded to s3
- Additionally, the log messages script was updated to accommodate s3 upload errors

Successful testing was conducted for an Archer run: 250716_XXXXXXXX_0389_XXXXXXXXXX - as shown in the logfiles (in testing/automate_demultiplexing_logfiles/sw_script_logfiles/ - dated May 22nd 15:13pm)
Successful testing was conducted for the MSK run: 260515_XXXXXXXX_0746_XXXXXXXXXX - as shown in the logfiles (in testing/automate_demultiplexing_logfiles/sw_script_logfiles/ - dated May 22nd 15:13pm)

*Note*
Also, we should consider using a platform agnostic upload started file-flag now that there are two places we upload data to. i.e. instead of DNANexus_upload_started.txt we use upload_started.txt. I've not changed this because I don't know what else interacts with this file that could potentially break.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/641)
<!-- Reviewable:end -->
