### PR TITLE
R134 CP2 test panel

### DIFF
--- a/config/panel_config.py
+++ b/config/panel_config.py
@@ -813,6 +813,14 @@ class PanelConfig:
             "congenica_project": 17995,
             "ed_cnvcalling_bedfile": "Pan5345",
         },
+          "Pan5357": {  # CP2 R134 (Synnovis) - FH small panel FOR TESTING ONLY
+            **CAPTURE_PANEL_DICT["CP2"],
+            **CONGENICA_CREDENTIALS["synnovis"],
+            "test_number": "R134",
+            "congenica_project": 4664,
+            "FH": True,
+            "ed_cnvcalling_bedfile": "Pan5313",
+        },
     }
     # ================ PAN NUMBER LISTS ===================================================
     PANELS = list(PANEL_DICT.keys())  # All panel pan numbers


### PR DESCRIPTION
Added a test panel for R134 CP2 to enable testing of the prior FH-PRS code changes in the pipeline.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/automate_demultiplex/646)
<!-- Reviewable:end -->
